### PR TITLE
Mise en place de l'option 'zoomToExtent' pour les couches KML

### DIFF
--- a/samples/data/marker.kml
+++ b/samples/data/marker.kml
@@ -1,0 +1,17 @@
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+	<Placemark>
+		<Style>
+			<IconStyle>
+				<Icon>
+					<href>data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAmCAYAAABpuqMCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAARfSURBVFiF3ZhfbBRVGMV/d2Z3212tbSkCbuNaqzaRiL6QyAMPjSFoYqgx4oOiRmMFUzQG479o2lQ0QXk1EhYFgmlD2mIRkYhRwqLEaA2GiKWV7rZLQ0sLwbZId7t/Zq4PFK1125m5s/vCedz7nXO+M9/N3jsD1xFEvgXlTkrI8hBQBywFbgEqgEvAMHAayZcYHBYbuZJP77yFkdsoR+ct4GXAb4OSQPARXj4QzzGejx7yEkZuZy2CMLBAgf4nkhfEi3S67UNzQ5YSIXfQhKAdtSAACxDsk2EapXT3cF2FYQdNSN7F/YQFsJkw77gVUcL01mp3o5EDJoK1Yj37VchKjcjdlJEmhvrWmg9jGNwhGhhzSlTbZmnepjBBAMrReF2F6Hgy0+fIKPb+flWRIMtip+eQ88lcPRCtg3gCCVZ3RqhPDbJepqlPDbJ6XwSvP2nDJYCXB522prLN6iwrPIEETw33U/VoLZovBPjQfCGqHqtl3XDUZiBrn1lQCXO3ZcUDLV34Su/JueYrW0btnp8tNSRLnTamEiZoWRF6uHre9dseuT0vPrOgEqbCWtW3xNX6VSy02c+/sk4JwF+WFWZ6xGL9vA2fyzb7+QcqYUYtKwYP9s+7PrA/bsNn/geSA87DSLosa44+fT/p8VM511Jjp4g8u8KGk7XPLKhM5qhlRSbppzV4JwMdEcz0WSCNmT5LrC1CS/AujKliSw1BxGljzm8AH3MjHs4BpU65DjCBn0rxDJNOSI4nM33F2O2U58yEnU6DgOpF02AzcEGJa40LZHlfhagUZvp6vkmFawObVK7/4PLFSoZpBZ50ozEThsne6i2hjZqmFRVJ6U8JUeSVUmQNzQvg0c1MVtNMIUTSl0pNLhsaGu8A4xrfbZhS4CRQ5SoFcCWtja/5NBg+N+GZsu0vhSEkcY8mf+iNx+OuX3llmJVABNCVNUA2fl3xWdvJkriqRBb2uPugAYgNHEey1Y3Gt3/ccNxFEAChm2al6zAAjNAEWF/rc1Ev6+ffOLTwmBt7E0xD02J5CSOayQLrsHMJnYGMITJvHrr588mUMKyr54CUaaHrnfF4fCQ/kwHEBmLAa044rb+WHP4xXnxJ0VJK6CkyjO2xWOx3KMSH8zDtwONWdb2jvt41u4JtChZJKeVveDwnYrHYfw5uj4KYFRpSWbGqyCPL5ypIpMTkKwcWfWVXUEqRRcio1LTuUCjUE4lEsrnq8j4ZgKEP9bpgmfHFHPpyy3fle3f9Uto3n4aUIqNhDghN6zZ1vTcajaasfAsSBmBwq7f11tLM/24Hx2L+n+rbF38zBy2JEP0anPEGAj3d3d1pJ56F2GYAGInM82M+bWW53wxd++3ipH7x1QMLj8ysk5BAyj6Ppp2+d/nyaEdHh/I/W8EmA3Ci2b/iviVT3+tCerMmxkudiz450hcYBSYQIqrDmScGBvqawSxkH3lDV2Pxe6ltItnWcFNLTXX1qpqamkoK/BCvC/wNB+l5MdQKNHsAAAAASUVORK5CYII=</href>
+					<gx:w>51</gx:w>
+					<gx:h>38</gx:h>
+				</Icon>
+				<hotSpot x="25.5" y="0" xunits="pixels" yunits="pixels"/>
+			</IconStyle>
+		</Style>
+		<Point>
+			<coordinates>2.313173720509765,48.84499101021504</coordinates>
+		</Point>
+	</Placemark>
+</kml>

--- a/samples/ol3/ol3-geojson.html
+++ b/samples/ol3/ol3-geojson.html
@@ -21,7 +21,7 @@
                 apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
                 center : {
                     x : -8181208,
-                    y : 6097147
+                    y : 5097147
                 },
                 controlsOptions : {
                     "layerSwitcher" : {}
@@ -33,7 +33,8 @@
                         opacity : 0.7,
                         minZoom : 5,
                         maxZoom : 10,
-                        visibility : true
+                        visibility : true,
+                        zoomToExtent : true
                     }
                 },
                 zoom : 8

--- a/samples/ol3/ol3-gpx.html
+++ b/samples/ol3/ol3-gpx.html
@@ -20,7 +20,7 @@
             var map = Gp.Map.load('geoportalMap',{
                 apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
                 center : {
-                    x : 986524,
+                    x : 786524,
                     y : 5099419
                 },
                 controlsOptions : {
@@ -40,6 +40,7 @@
                         minZoom : 9,
                         maxZoom : 13,
                         visibility : true,
+                        zoomToExtent : true,
                         // cross-domain sur ce fichier :
                         // url : "http://api.ign.fr/tech-docs-js/data/Campomoro-Tizzano-Sartene_3029.gpx",
                         url : "../data/Campomoro-Tizzano-Sartene_3029.gpx",

--- a/samples/ol3/ol3-kml-drawing.html
+++ b/samples/ol3/ol3-kml-drawing.html
@@ -41,7 +41,8 @@
                         format : "kml",
                         url : "../data/croquis-drawingtool.kml",
                         extractStyles : true,
-                        showPointNames : true
+                        showPointNames : true,
+                        zoomToExtent : true
                     }
                 },
                 zoom : 5

--- a/samples/ol3/ol3-kml-drawing.html
+++ b/samples/ol3/ol3-kml-drawing.html
@@ -43,6 +43,19 @@
                         extractStyles : true,
                         showPointNames : true,
                         zoomToExtent : true
+                    },
+                    MonMarker : {
+                        opacity : 1,
+                        minZoom : 1,
+                        maxZoom : 21,
+                        visibility : true,
+                        title : "Croquis",
+                        description : "mon marker en KML",
+                        format : "kml",
+                        url : "../data/marker.kml",
+                        extractStyles : true,
+                        showPointNames : true,
+                        zoomToExtent : false
                     }
                 },
                 zoom : 5

--- a/samples/ol3/ol3-kml.html
+++ b/samples/ol3/ol3-kml.html
@@ -6,8 +6,8 @@
         <link rel="stylesheet" href="../../dist/ol3/GpOl3-src.css" type="text/css">
         <style>
         #geoportalMap {
-            height: 400px;
-            width: 600px;
+            height: 800px;
+            width: 800px;
         }
         </style>
         <script src="../../dist/ol3/GpOl3-src.js"></script>

--- a/samples/ol3/ol3-wfs-geoportail.html
+++ b/samples/ol3/ol3-wfs-geoportail.html
@@ -37,7 +37,8 @@
                         // outputFormat : "text/xml; subtype=gml/2.1.2",
                         maxFeatures : 200,
                         projection : "EPSG:4326",
-                        visibility : true
+                        visibility : true,
+                        zoomToExtent : false
                     }
                 },
                 controlsOptions : {

--- a/src/Map.js
+++ b/src/Map.js
@@ -371,6 +371,7 @@
          * | - | - | - |
          * | showPointNames | Boolean | If true, show names as labels for placemarks which contain points. |
          * | extractStyles | Boolean | If true, the styles of the features are recovered from the file. |
+         * | zoomToExtent | Boolean | If true, zoom into the extent of features. | 
          * | projection | String | coordinate reference system id used for Layer (default is map projection) |
          *
          * ### KML, GPX and GeoJSON specific properties

--- a/src/ol3/OL3.js
+++ b/src/ol3/OL3.js
@@ -1887,7 +1887,8 @@ define([
                                 if (_stateExtent === "ready" && _sourceExtent[0] !== Infinity) {
                                     ol.Observable.unByKey(key);
                                     _map.getView().fit(_sourceExtent, {
-                                        size : _map.getSize()
+                                        // size : _map.getSize(),
+                                        maxZoom : 18
                                     });
                                 }
                             });

--- a/src/ol3/OL3.js
+++ b/src/ol3/OL3.js
@@ -1868,8 +1868,36 @@ define([
                     obj : layer,
                     options : layerOpts
                 }) ;
+
                 this.libMap.addLayer(layer) ;
                 this._addLayerConfToLayerSwitcher(layer,layerOpts) ;
+
+                // action du type fit() sur les couches KML
+                if (layerOpts.format.toUpperCase() === "KML") {
+                    var _map = this.libMap;
+                    var _vectorSource = constructorOpts.source;
+                    if ( _map.getView() && _map.getSize() && _vectorSource.getExtent ) {
+
+                        var _fit  = layerOpts.zoomToExtent || false;
+                        if (_fit) {
+
+                            var key = _vectorSource.on("change", function () {
+                                var _sourceExtent = _vectorSource.getExtent();
+                                var _stateExtent  = _vectorSource.getState();
+                                if (_stateExtent === "ready" && _sourceExtent[0] !== Infinity) {
+                                    ol.Observable.unByKey(key);
+                                    _map.getView().fit(_sourceExtent, {
+                                        size : _map.getSize()
+                                    });
+                                }
+                            });
+
+                            setTimeout(function () {
+                                _vectorSource.dispatchEvent("change");
+                            },100);
+                        }
+                    }
+                }
             }
         } ;
 

--- a/src/ol3/OL3.js
+++ b/src/ol3/OL3.js
@@ -1856,12 +1856,14 @@ define([
                 default:
 
             }
+
             if (constructorOpts.hasOwnProperty("source")) {
 
                 // le controle geoportalAttribution exploite la propriete _originators
                 if (layerOpts.hasOwnProperty("originators")) {
                     constructorOpts.source._originators = layerOpts.originators ;
                 }
+
                 var layer = new ol.layer.Vector(constructorOpts) ;
                 this._layers.push({
                     id : layerId,
@@ -1872,33 +1874,32 @@ define([
                 this.libMap.addLayer(layer) ;
                 this._addLayerConfToLayerSwitcher(layer,layerOpts) ;
 
-                // action du type fit() sur les couches KML
-                if (layerOpts.format.toUpperCase() === "KML") {
-                    var _map = this.libMap;
-                    var _vectorSource = constructorOpts.source;
-                    if ( _map.getView() && _map.getSize() && _vectorSource.getExtent ) {
+                var _map = this.libMap;
+                var _vectorSource = constructorOpts.source;
+                // "getExtent" pour les vecteurs
+                if ( _map.getView() && _map.getSize() && _vectorSource.getExtent ) {
 
-                        var _fit  = layerOpts.zoomToExtent || false;
-                        if (_fit) {
+                    var _fit  = layerOpts.zoomToExtent || false;
+                    if (_fit) {
 
-                            var key = _vectorSource.on("change", function () {
-                                var _sourceExtent = _vectorSource.getExtent();
-                                var _stateExtent  = _vectorSource.getState();
-                                if (_stateExtent === "ready" && _sourceExtent[0] !== Infinity) {
-                                    ol.Observable.unByKey(key);
-                                    _map.getView().fit(_sourceExtent, {
-                                        // size : _map.getSize(),
-                                        maxZoom : 18
-                                    });
-                                }
-                            });
+                        var key = _vectorSource.on("change", function () {
+                            var _sourceExtent = _vectorSource.getExtent();
+                            var _stateExtent  = _vectorSource.getState();
+                            if (_stateExtent === "ready" && _sourceExtent[0] !== Infinity) {
+                                ol.Observable.unByKey(key);
+                                _map.getView().fit(_sourceExtent, {
+                                    // size : _map.getSize(),
+                                    maxZoom : 18
+                                });
+                            }
+                        });
 
-                            setTimeout(function () {
-                                _vectorSource.dispatchEvent("change");
-                            },100);
-                        }
+                        setTimeout(function () {
+                            _vectorSource.dispatchEvent("change");
+                        },100);
                     }
                 }
+
             }
         } ;
 


### PR DESCRIPTION
Mise en place de l'option 'zoomToExtent' (cf. layerOptions) sur les couches de type 'KML' (drawing)

```
var map = Gp.Map.load('geoportalMap',{
                apiKey : "...",
                layersOptions : {
                    maCoucheKML : {
                        opacity : 0.7,
                        minZoom : 1,
                        maxZoom : 21,
                        visibility : true,
                        title : "Croquis",
                        description : "ma couche croquis en KML",
                        format : "kml",
                        url : "../data/croquis-drawingtool.kml",
                        extractStyles : true,
                        showPointNames : true,
                        zoomToExtent : true
                    }
                }
            });
```