### PR TITLE
Vector tile/fix switch 3d 2d

### DIFF
--- a/src/Itowns/ItMapListeners.js
+++ b/src/Itowns/ItMapListeners.js
@@ -855,6 +855,12 @@ ItMap.prototype._addMapBoxLayer = function (layerObj) {
     vectorTileLayer.visible = (layerOpts.visibility === undefined) ? true : layerOpts.visibility;
     vectorTileLayer.opacity = (layerOpts.opacity === undefined) ? 1 : layerOpts.opacity;
 
+    var LSControl = this.getLibMapControl("layerswitcher");
+    // if the LS already exists, we have to save the conf of the layer to add it to the LS
+    if (LSControl) {
+        LSControl._addedLayerConf[layerId] = layerOpts;
+    }
+
     // on met à jour le tableau des couches
     this._layers.push({
         id : layerId,

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -1449,6 +1449,15 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             p.layer.once("change:source", setStyle);
                                         }
 
+                                        // Maintenant que la couche mapBox a été ajoutée de manière asynchrone,
+                                        // on s'assure de bien remettre à jour les indexs des couches et de 
+                                        // reordonner les couches correctement (desynchro dans le cas d'un switch 3D->2D)
+                                        for (var i = 0; i < self._layers.length; i++) {
+                                            var layerName = self._layers[i].id;
+                                            self._layers[i].options.position = self.mapOptions.layersOptions[layerName].position;
+                                            self._layers[i].obj.setZIndex(self._layers[i].options.position);
+                                        }
+
                                         // maj du gestionnaire de couche
                                         self._addLayerConfToLayerSwitcher(p.layer, p.options);
 

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -1450,12 +1450,17 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                         }
 
                                         // Maintenant que la couche mapBox a été ajoutée de manière asynchrone,
-                                        // on s'assure de bien remettre à jour les indexs des couches et de 
-                                        // reordonner les couches correctement (desynchro dans le cas d'un switch 3D->2D)
+                                        // on s'assure de bien remettre à jour les indexs des couches et de
+                                        // reordonner les couches correctement (désynchro des zIndex dans le cas d'un switch 3D->2D)
+                                        // On entre pas dans la condition si les IDs des couches ne correspondent pas entre
+                                        // les couches contenues dans_layers et mapOptions.layersOptions
+                                        // cf. FIXME couche ORTHO dans afterGetConfig
                                         for (var i = 0; i < self._layers.length; i++) {
                                             var layerName = self._layers[i].id;
-                                            self._layers[i].options.position = self.mapOptions.layersOptions[layerName].position;
-                                            self._layers[i].obj.setZIndex(self._layers[i].options.position);
+                                            if (self.mapOptions.layersOptions && self.mapOptions.layersOptions[layerName] && self.mapOptions.layersOptions[layerName].position !== undefined) {
+                                                self._layers[i].options.position = self.mapOptions.layersOptions[layerName].position;
+                                                self._layers[i].obj.setZIndex(self._layers[i].options.position);
+                                            }
                                         }
 
                                         // maj du gestionnaire de couche


### PR DESCRIPTION
Les couches mapBox sont ajoutées en 2D de manière asynchrone : on attend de parser le fichier de style avant d'ajouter la couche VT à la visu.

Problème : lors du switch 3D -> 2D, la visu 2D se charge avec toutes les couches, sauf les couches vecteur tuilé. Cela créé des problèmes dans l'ordonnancement des couches qui n'est alors plus respecté.

Pour contourner ce problème, en 2D, on ré-ordonne toutes les couches présentes sur la visu à la fin du callback chargé de l'ajout des couches vecteur tuilé.