### PR TITLE
ajout d'info du build dans les bundles

### DIFF
--- a/licences/licence-ign.tmpl
+++ b/licences/licence-ign.tmpl
@@ -6,10 +6,14 @@
  * @see http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  * @see http://www.cecill.info/
  *
- * @copyright copyright (c) IGN 
+ * @copyright copyright (c) IGN
  * @license CeCILL-B
  * @author IGN
  * @version {__VERSION__}
  * @date {__DATE__}
- *
+ * @build
+ *    date   : {__BUILD_DATE__}
+ *    branch : {__GIT_BRANCH__}
+ *    commit : {__GIT_COMMIT__}
+ *    dirty  : {__GIT_STATUS__}
  */

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "replace-bundle-webpack-plugin": "^1.0.0",
         "requirejs": "^2.3.6",
         "responsive-loader": "^1.2.0",
+        "shelljs": "^0.8.3",
         "speed-measure-webpack-plugin": "^1.3.0",
         "string-template": "^1.0.0",
         "style-loader": "^0.23.1",

--- a/webpack.config.2d.js
+++ b/webpack.config.2d.js
@@ -6,6 +6,10 @@ var path = require("path");
 var webpack = require("webpack");
 var header = require("string-template");
 var glob = require("glob");
+// var spawn = require('cross-spawn');
+var shell = require('shelljs');
+
+shell.config.silent = true;
 
 // -- plugins
 var DefineWebpackPlugin = webpack.DefinePlugin;
@@ -379,7 +383,11 @@ module.exports = (env, argv) => {
                 banner : header(fs.readFileSync(path.join(__dirname, "licences", "licence-ign.tmpl"), "utf8"), {
                     __BRIEF__ : pkg.description,
                     __VERSION__ : pkg.SDK2DVersion,
-                    __DATE__ : pkg.date
+                    __DATE__ : pkg.date,
+                    __BUILD_DATE__ : new Date().toLocaleString("fr-FR", { timeZone: 'UTC' }),
+                    __GIT_BRANCH__ : shell.exec('git name-rev --name-only HEAD').stdout.trim(),
+                    __GIT_COMMIT__ : shell.exec('git rev-parse --short HEAD').stdout.trim(),
+                    __GIT_STATUS__ : shell.exec('git status -s -uall').stdout.trim().length > 0
                 }),
                 raw : true,
                 entryOnly : true

--- a/webpack.config.3d.js
+++ b/webpack.config.3d.js
@@ -6,6 +6,9 @@ var path = require("path");
 var webpack = require("webpack");
 var header = require("string-template");
 var glob = require("glob");
+var shell = require('shelljs');
+
+shell.config.silent = true;
 
 // -- plugins
 var DefineWebpackPlugin = webpack.DefinePlugin;
@@ -441,7 +444,11 @@ module.exports = (env, argv) => {
                 banner : header(fs.readFileSync(path.join(__dirname, "licences", "licence-ign.tmpl"), "utf8"), {
                     __BRIEF__ : pkg.description,
                     __VERSION__ : pkg.SDK3DVersion,
-                    __DATE__ : pkg.date
+                    __DATE__ : pkg.date,
+                    __BUILD_DATE__ : new Date().toLocaleString("fr-FR", { timeZone: 'UTC' }),
+                    __GIT_BRANCH__ : shell.exec('git name-rev --name-only HEAD').stdout.trim(),
+                    __GIT_COMMIT__ : shell.exec('git rev-parse --short HEAD').stdout.trim(),
+                    __GIT_STATUS__ : shell.exec('git status -s -uall').stdout.trim().length > 0
                 }),
                 raw : true,
                 entryOnly : true


### PR DESCRIPTION
Une information du **build** est ajoutée dans l'entête des bundles : 
```
/*!
 * @brief French Geoportal SDK based on OpenLayers (2D) and iTowns (3D) libraries
 *
 * This software is released under the licence CeCILL-B (Free BSD compatible)
 * @see http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
 * @see http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
 * @see http://www.cecill.info/
 *
 * @copyright copyright (c) IGN
 * @license CeCILL-B
 * @author IGN
 * @version 3.0.8
 * @date 06/03/2020
 * @build
 *    date   : 2020-3-15 2:17:29 AM
 *    branch : develop
 *    commit : 4b037773
 *    dirty  : true
 */
```
4 informations qui nous permet d'identifier le **build** : 
 *    date   : 2020-3-15 2:17:29 AM
 *    branch : develop
 *    commit : 4b037773
 *    dirty  : 
**false** si toutes les sources ont été poussé...
**true** si il existe encore des sources locales...
