### PR TITLE
feat(2D:Interface): Ajout du paramètre extent au chargement de la carte

### DIFF
--- a/samples-src/pages/2d/page-extent-amd.html
+++ b/samples-src/pages/2d/page-extent-amd.html
@@ -1,0 +1,38 @@
+{{#extend "sample-amd-layout-2d"}}
+
+{{#content "head"}}
+    <title>Sample SDK 2D Azimuth</title>
+{{/content}}
+
+{{#content "style"}}
+    <style>
+        div#map {
+            max-width: 100%;
+            height: 500px;
+        }
+    </style>
+{{/content}}
+
+{{#content "body"}}
+    <h2>Contrôle de l'azimuth en mode AMD</h2>
+    <!-- map -->
+    <div id="map">
+    </div>
+{{/content}}
+
+{{#content "js"}}
+    <script>
+        requirejs([
+          "Gp"
+        ],
+        function (
+          Gp
+        ) {
+            Gp.Map.load('map', {
+                apiKey : "{{apikey}}",
+                extent : [-572513.341856, 5211017.966314, 916327.095083, 6636950.728974]
+            });
+        });
+    </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/2d/page-extent-bundle.html
+++ b/samples-src/pages/2d/page-extent-bundle.html
@@ -1,0 +1,32 @@
+{{#extend "sample-bundle-layout-2d"}}
+
+{{#content "head"}}
+    <title>Sample SDK 2D Extent</title>
+{{/content}}
+
+{{#content "style"}}
+    <style>
+        div#map {
+            max-width: 100%;
+            height: 500px;
+        }
+    </style>
+{{/content}}
+
+{{#content "body"}}
+    <h2>Extent contrainte de la vue</h2>
+    <!-- map -->
+    <div id="map">
+    </div>
+{{/content}}
+
+{{#content "js"}}
+    <script>
+        Gp.Map.load('map', {
+            // apiKey : "{{apikey}}",
+            configUrl : "{{resources}}/autoconf.js",
+            extent : [-572513.341856, 5211017.966314, 916327.095083, 6636950.728974]
+        });
+    </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/3d/page-extent-bundle.html
+++ b/samples-src/pages/3d/page-extent-bundle.html
@@ -1,0 +1,57 @@
+{{#extend "sample-bundle-layout-3d"}}
+
+{{#content "head"}}
+    <title>Sample SDK 3D Extent</title>
+{{/content}}
+
+{{#content "style"}}
+    <style>
+        #viewerDiv {
+          height: 600px;
+          width: 1200px;
+          position : "relative";
+        }
+    </style>
+{{/content}}
+
+{{#content "body"}}
+    <h1>Test 3D</h1>
+    <h2>Carte 3D.</h2>
+    <div id="BoutonSwitchToItowns">
+        <input type="button" name="switch" onclick="switchTo3D();" value="Switch from 2D to 3D"/><br/>
+    </div>
+    <div id="BoutonSwitchToOl" hidden>
+        <input type="button" name="switch" onclick="switchTo2D();" value="Switch from 3D to 2D"/><br/>
+    </div>
+    <div id="viewerDiv"></div>
+{{/content}}
+
+{{#content "js"}}
+    <script>
+        var map = Gp.Map.load("viewerDiv",{
+            configUrl : "{{resources}}/autoconf.js", // apiKey : "{{apikey}}",
+            viewMode : "2d",
+            layersOptions : {
+                "ORTHOIMAGERY.ORTHOPHOTOS" : {}
+            },
+            center : {
+                x : 2.357,
+                y : 48.83
+            },
+            extent : [-572513.341856, 5211017.966314, 916327.095083, 6636950.728974]
+        });
+
+        function switchTo3D() {
+            map = map.switch2D3D("3d");
+            document.getElementById("BoutonSwitchToOl").style.display = "inline";
+            document.getElementById("BoutonSwitchToItowns").style.display = "none";
+        };
+
+        function switchTo2D() {
+            map = map.switch2D3D("2d");
+            document.getElementById("BoutonSwitchToItowns").style.display = "inline";
+            document.getElementById("BoutonSwitchToOl").style.display = "none";
+        };
+    </script>
+{{/content}}
+{{/extend}}

--- a/src/Interface/IMapBase.js
+++ b/src/Interface/IMapBase.js
@@ -25,6 +25,7 @@ var switch2D3D = function (viewMode) {
     oldMap.controlsOptions = this.getControlsOptions();
     oldMap.mapDiv = this.div.id;
     oldMap.apiKey = this.apiKey;
+    oldMap.extent = this.mapOptions.extent !== undefined ? this.mapOptions.extent : null;
     oldMap.enableRotation = this.mapOptions.enableRotation !== undefined ? this.mapOptions.enableRotation : null;
     oldMap.mapEventsOptions = this.mapOptions.mapEventsOptions !== undefined ? this.mapOptions.mapEventsOptions : null;
 
@@ -77,6 +78,7 @@ var switch2D3D = function (viewMode) {
             enableRotation : oldMap.enableRotation,
             projection : oldMap.projection,
             center : oldMap.center,
+            extent : oldMap.extent,
             azimuth : oldMap.azimuth,
             tilt : oldMap.tilt,
             zoom : oldMap.zoom,

--- a/src/Map.js
+++ b/src/Map.js
@@ -204,7 +204,7 @@ var mapLoadedEvent = {
  * | enableRotation | Boolean | optional | true | Map rotation. Default is true. If false a rotation constraint that always sets the rotation to zero is used. |
  * | markersOptions | Array.<{@link Gp.MarkerOptions Gp.MarkerOptions}> | optional | | Options for displaying markers on the map. |
  * | projection | String | optional | "EPSG:3857" | Projection code (in EPSG or IGNF register) for the map. Not available in 3D as the projection is always "EPSG:4326" |
- * | extent | Array | optional | | Forced extent of the view, with the format [west, east, north, south]
+ * | extent | Array | optional | | Forced extent of the view, with the format [west, south, east, north], with the projection of the map
  * 
  * * **Specific 3D options**
  *

--- a/src/Map.js
+++ b/src/Map.js
@@ -204,7 +204,8 @@ var mapLoadedEvent = {
  * | enableRotation | Boolean | optional | true | Map rotation. Default is true. If false a rotation constraint that always sets the rotation to zero is used. |
  * | markersOptions | Array.<{@link Gp.MarkerOptions Gp.MarkerOptions}> | optional | | Options for displaying markers on the map. |
  * | projection | String | optional | "EPSG:3857" | Projection code (in EPSG or IGNF register) for the map. Not available in 3D as the projection is always "EPSG:4326" |
- *
+ * | extent | Array | optional | | Forced extent of the view, with the format [west, east, north, south]
+ * 
  * * **Specific 3D options**
  *
  * | property | Type | Argument | Default | Description |

--- a/src/OpenLayers/OlMapBase.js
+++ b/src/OpenLayers/OlMapBase.js
@@ -54,6 +54,7 @@ OlMap.prototype._initMap = function () {
         // center : [center.x, center.y],
         enableRotation : this.mapOptions.enableRotation,
         zoom : this.mapOptions.zoom,
+        extent : this.mapOptions.extent,
         minZoom : this.mapOptions.minZoom,
         maxZoom : this.mapOptions.maxZoom,
         projection : this.mapOptions.projection,


### PR DESCRIPTION
Le paramètre extent permet de contraindre la navigation de la vue. Pour le moment, fonctionnel qu'en 2D (mais paramètre conservé en 3D pour switch).

Voir la demande sur le forum : https://www.developpez.net/forums/d2077108/applications/sig-systeme-d-information-geographique/ign-api-geoportail/sdk-bloquer-l-emprise-chargement-vue-carte/

## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [x] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [x] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [ ] Bugfix
- [x] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [x] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
<!-- Décrire le comportement actuel qui est modifié, pourquoi il est modifié et, eventuellement, citer des tickets concernés -->
Impossible de contraindre la navigation sur la vue avec le SDK.

Numéro du ticket : https://www.developpez.net/forums/d2077108/applications/sig-systeme-d-information-geographique/ign-api-geoportail/sdk-bloquer-l-emprise-chargement-vue-carte/


## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Le paramètre extent au chargement permet de contraindre la vue à une emprise donnée.

Voir exemples 2d/page-extent-bundle.html et 3d/page-extent-bundle.html

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations
RDEV-34548
