### PR TITLE
Mise en place d’événements sur la modification des propriétés des couche vecteurs tuilés

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -14,9 +14,12 @@ Correctifs divers et ajouts
 	- Ajout de l'option extent au chargement de la carte (#57)
 	- Ajout guide de bonnes pratiques de developpement (84047c80a45333a692e6f28fc7bc4a7c56d233d6)
 	- !A VENIR! Ajout du control d'exageration du relief (boostRelief)
-	- VectorTile 2D (mapbox) :
-		- Ajout d'un exemple de menu des thèmes et des filtres
-		- Ajout des événements sur les changements sur les properties
+	- Évolution sur le VectorTile 2D (mapbox) :
+		- Ajout d'un exemple d’implémentation de menu
+			- des thèmes,
+			- des filtres,
+			- de la légende
+		- Ajout des événements sur les changements sur les "properties"
 
 * [Changed]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -32,6 +32,7 @@ Correctifs divers et ajouts
 
 	- fix fonctionnalité noir et blanc avec Chrome v83+ (892c55bee89a2cac9448e28d80cc19ddb9617cdb)
 	- fix sur la gestion des événements (#56)
+	- fix la gestion des filtres attributaires sur le VectorTile 2D (mapbox)
 
 * [Deprecated]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -14,6 +14,9 @@ Correctifs divers et ajouts
 	- Ajout de l'option extent au chargement de la carte (#57)
 	- Ajout guide de bonnes pratiques de developpement (84047c80a45333a692e6f28fc7bc4a7c56d233d6)
 	- !A VENIR! Ajout du control d'exageration du relief (boostRelief)
+	- VectorTile 2D (mapbox) :
+		- Ajout d'un exemple de menu des thèmes et des filtres
+		- Ajout des événements sur les changements sur les properties
 
 * [Changed]
 

--- a/samples-src/pages/2d/page-mapbox-tilejson-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-tilejson-bundle.html
@@ -217,77 +217,79 @@
 
                 var filters = layer.get("mapbox-filters").filters;
                 for (var i = 0; i < filters.length; i++) {
-                    var _name = filters[i].filterName;
-                    var _style =  filters[i].style;
+                    (function(filters) {
+                        var _name = filters[i].filterName;
+                        var _style =  filters[i].style;
 
-                    var label = document.createElement('label');
-                    label.id = "editor-filtres-" + i;
-                    label.className = '';
-                    label.innerHTML = _name; // titre de la 'facette'
+                        var label = document.createElement('label');
+                        label.id = "editor-filtres-" + i;
+                        label.className = '';
+                        label.innerHTML = _name; // titre de la 'facette'
 
-                    divEditorFiltres.appendChild(label);
+                        divEditorFiltres.appendChild(label);
 
-                    // Editeur de filtres
-                    var editor = new ol.style.Editor({
-                        target : divEditorFiltres,
-                        id : i,
-                        style : _style,
-                        tools : {
-                            themes : false,
-                            layers : true,
-                            filter : false,
-                            style : false,
-                            legend : false,
-                            title : true,
-                            group : false,
-                            sort : true, // on trie les filtres afin d'avoir un permalien conforme à la liste des filtres !
-                            title : false,
-                            type : false,
-                            pin : false
-                        },
-                        events : {
-                            "editor:layer:onclickvisibility" : function (e) {
-                                // recherche de l'editeur de style
-                                var editorCurrent = null;
-                                for (var p = 0; p < editorFiltres.length; p++) {
-                                    var _editor = editorFiltres[p];
-                                    var s = _editor.getContainer().innerHTML;
-                                    if (s.indexOf(e.target.srcElement.id) !== -1) {
-                                        editorCurrent = _editor;
+                        // Editeur de filtres
+                        var editor = new ol.style.Editor({
+                            target : divEditorFiltres,
+                            id : i.toString(),
+                            style : _style,
+                            tools : {
+                                themes : false,
+                                layers : true,
+                                filter : false,
+                                style : false,
+                                legend : false,
+                                title : true,
+                                group : false,
+                                sort : true, // on trie les filtres afin d'avoir un permalien conforme à la liste des filtres !
+                                title : false,
+                                type : false,
+                                pin : false
+                            },
+                            events : {
+                                "editor:layer:onclickvisibility" : function (e) {
+                                    // recherche de l'editeur de style
+                                    var editorCurrent = null;
+                                    for (var p = 0; p < editorFiltres.length; p++) {
+                                        var _editor = editorFiltres[p];
+                                        var s = _editor.getContainer().innerHTML;
+                                        if (s.indexOf(e.target.srcElement.id) !== -1) {
+                                            editorCurrent = _editor;
+                                        }
                                     }
-                                }
-                                // on recupere des informations
-                                var data = e.target.data.obj;
-                                var target = e.target.srcElement;
-                                var category = editorCurrent.getStyle().name;
-                                var status = [];
-                                for (var nn = 0; nn < editorCurrent.getLayers().length; nn++) {
-                                    var o = editorCurrent.getLayers()[nn];
-                                    status.push((o.visibility()) ? 1 : 0);
-                                }
+                                    // on recupere des informations
+                                    var data = e.target.data.obj;
+                                    var target = e.target.srcElement;
+                                    var category = editorCurrent.getStyle().name;
+                                    var status = [];
+                                    for (var nn = 0; nn < editorCurrent.getLayers().length; nn++) {
+                                        var o = editorCurrent.getLayers()[nn];
+                                        status.push((o.visibility()) ? 1 : 0);
+                                    }
 
-                                // choix du filtre
-                                globalMap._updateFilterMapBoxLayer(layer, "planign", {
-                                    data:data,
-                                    active:target.checked,
-                                    category:category,
-                                    status:status
-                                })
-                                .then(function () {
+                                    // choix du filtre
+                                    globalMap._updateFilterMapBoxLayer(layer, "planign", {
+                                        data:data,
+                                        active:target.checked,
+                                        category:category,
+                                        status:status
+                                    })
+                                    .then(function () {
 
-                                })
-                                .catch(function (error) {
-                                    console.error(error);
-                                });
+                                    })
+                                    .catch(function (error) {
+                                        console.error(error);
+                                    });
+                                }
                             }
-                        }
-                    });
-                    editor.createElement()
-                        .then(function () {
-                            // enregistrement de l'editeur
-                            editorFiltres.push(editor);
+                        });
+                        editor.createElement()
+                            .then(function () {
+                                // enregistrement de l'editeur
+                                editorFiltres.push(editor);
 
-                        })
+                            });
+                    })(filters);
                 }
             }
         });

--- a/samples-src/pages/2d/page-mapbox-tilejson-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-tilejson-bundle.html
@@ -19,7 +19,7 @@
             /* overflow-x: hidden; */
             height: 500px;
         }
-        #themes, #filtres {
+        #themes, #filtres, #legendes {
             display: flex;
             flex-direction: column;
             width: 300px;
@@ -47,6 +47,10 @@
                 <button id="button-editor-filtres">Editeur de filtres</button>
                 <div id="editor-filtres"></div>
             </div>
+            <div id="legendes">
+                <button id="button-editor-legendes">Afficher les legendes</button>
+                <div id="editor-legendes"></div>
+            </div>
         </div>
     </div>
 {{/content}}
@@ -55,6 +59,7 @@
     <script>
         var layer = null;
         var editorThemes = null;
+        var editorLegendes = null;
         var editorFiltres = [];
         var globalMap = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
@@ -136,6 +141,66 @@
                 "layerChanged" : function (e) {},
                 "mapLoaded" : function (e) {}
             }
+        });
+
+        function addLegende() {
+            var divEditorLegendes = document.getElementById("editor-legendes");
+
+            // on recupere les informations
+            layer = globalMap.getLibMap().getLayers().getArray()[1]; // ["planign"]
+            var _url = null;
+            var _styles = layer.get("mapbox-themes").styles;
+            for (var i = 0; i < _styles.length; i++) {
+                var s = _styles[i];
+                if (s.selected) {
+                    _url = s.url;
+                    break;
+                }
+            }
+            // on ajoute l'éditeur minimaliste
+            editorLegendes = new ol.style.Editor({
+                target : divEditorLegendes,
+                style : _url,
+                tools : {
+                    layers : true,
+                    filter : false,
+                    style : false,
+                    legend : true,
+                    group : true,
+                    sort : true,
+                    title : false,
+                    type : false,
+                    pin : false,
+                    visibility : false,
+                    editable : false
+                }
+            });
+            editorLegendes.createElement();
+        }
+        function updateLegende() {
+            var divEditorLegendes = document.getElementById("editor-legendes");
+            // reconstruction de la legende
+            if (editorLegendes) {
+                while (divEditorLegendes.firstChild) {
+                    divEditorLegendes.removeChild(divEditorLegendes.firstChild);
+                }
+            }
+
+            addLegende();
+        }
+        document.getElementById("button-editor-legendes").addEventListener("click", (e) => {
+            var divEditorLegendes = document.getElementById("editor-legendes");
+
+            if (divEditorLegendes.style.display === "none" || divEditorLegendes.style.display === "") {
+                divEditorLegendes.style.display = "block";
+            } else {
+                divEditorLegendes.style.display = "none";
+            }
+
+            if (! editorLegendes) {
+                addLegende();
+            }
+
         });
 
         document.getElementById("button-editor-filtres").addEventListener("click", (e) => {
@@ -264,7 +329,7 @@
                             // changement de themes
                             globalMap._updateStyleMapBoxLayer(layer, "planign", {url:url, index:idx})
                             .then(function () {
-
+                                updateLegende();
                             })
                             .catch(function (error) {
                                 console.error(error);

--- a/samples-src/pages/2d/page-mapbox-tilejson-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-tilejson-bundle.html
@@ -6,26 +6,62 @@
 
 {{#content "style"}}
     <style>
+        #container {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            align-items: flex-start
+        }
+        #editors {
+            display: flex;
+            flex-direction: column;
+            overflow-y: scroll;
+            /* overflow-x: hidden; */
+            height: 500px;
+        }
+        #themes, #filtres {
+            display: flex;
+            flex-direction: column;
+            width: 300px;
+        }
         #geoportalMap {
-            height: 800px;
-            width: 800px;
+            height: 500px;
+            width: 500px;
         }
     </style>
 {{/content}}
 
 {{#content "body"}}
     <h1>Une carte affichant une couche MapBox avec un TileJson</h1>
-    <p>NB : le clic sur les features s'obtient par l'ajout du controle GetFeatureInfo (ici : caché et activé).</p>
-    <div id="geoportalMap"></div>
+    <h2>Implementation du changement de themes et selection des filtres</h2>
+    <p>NB : 2 boutons pour afficher les themes et les filtres.</p>
+    <p>NB : activer le filtre CHATEAU_SURF, et voir le resultat sur le Chateau de Vincennes</p>
+    <div id="container">
+        <div id="geoportalMap"></div>
+        <div id="editors">
+            <div id="themes">
+                <button id="button-editor-themes">Editeur de themes</button>
+                <div id="editor-themes"></div>
+            </div>
+            <div id="filtres">
+                <button id="button-editor-filtres">Editeur de filtres</button>
+                <div id="editor-filtres"></div>
+            </div>
+        </div>
+    </div>
 {{/content}}
 
 {{#content "js"}}
     <script>
+        var layer = null;
+        var editorThemes = null;
+        var editorFiltres = [];
         var globalMap = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
+            zoom : 15,
             center:{
-                x : 407444,
-                y : 5856585
+                x : 271158,
+                y : 6248295
             },
             controlsOptions : {
                 "layerSwitcher" : {},
@@ -39,9 +75,10 @@
             },
             layersOptions : {
                 'GEOGRAPHICALGRIDSYSTEMS.MAPS': {
+                    visibility : false
                 },
                 'planign' : {
-                    opacity : 0.7,
+                    opacity : 1,
                     zoomToExtent : true,
                     visibility : true,
                     format : "MapBox",
@@ -50,39 +87,193 @@
                     url : "{{resources}}/MAPBOX/styles/planign/planign.json",
                     styles : [
                         {
+                            "name" : "style par defaut",
+                            "url" : "{{resources}}/MAPBOX/styles/planign/planign.json"
+                        },
+                        {
                             "name" : "style 'gris'",
-                            // "url" : "https://vectortiles.ign.fr/demonstrateur/styles/gris.json"
                             "url" : "{{resources}}/MAPBOX/styles/planign/gris.json",
-                            "selected" : true
                         },
                         {
                             "name" : "style 'muet'",
-                            // "url" : "https://vectortiles.ign.fr/demonstrateur/styles/muet.json",
-                            "url" : "{{resources}}/MAPBOX/styles/planign/muet.json"
+                            "url" : "{{resources}}/MAPBOX/styles/planign/muet.json",
+                            "selected" : true
                         },
                     ],
-                    filtersSummary : "Filtres",
                     filters : [
-                       {
-                           propertyName:"bati_ponc.symbo",
-                           filterName:"Batiments ponctuels",
-                           configuration : {
-                               type : 0,
-                               selected:[0,1,1,1,1,1,1,1]
-                           }
-                       },
-                       {
-                           propertyName:"bati_surf.symbo",
-                           filterName:"Batiments surfaciques",
-                           configuration : {
-                               type : 0,
-                               selected:[0,1,1,1,1,1,1,1]
-                           }
-                       }
+                        {
+                            propertyName:"bati_surf.symbo",
+                            filterName:"Batiments surfaciques",
+                            configuration : {
+                                type : 0,
+                                selected:[1,1,1,1,0,1,1,1,1,1,1,0,1,0,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0]
+                            }
+                        },
+                        {
+                            propertyName:"bati_zai.nature",
+                            filterName:"Batiments ZAI"
+                        },
+                        {
+                            propertyName:"hydro_ponc.symbo",
+                            filterName:"Hydro ponctuels"
+                        },
+                        {
+                            propertyName:"limite_lin.symbo",
+                            filterName:"Limites administratives"
+                        },
+                        {
+                            propertyName:"bati_ponc.symbo",
+                            filterName:"Batiments ponctuels",
+                            configuration : {
+                                selected:[],
+                                type:0
+                            }
+                        }
                     ]
                 }
             },
-            zoom : 6
+            mapEventsOptions : {
+                "layerChanged" : function (e) {},
+                "mapLoaded" : function (e) {}
+            }
+        });
+
+        document.getElementById("button-editor-filtres").addEventListener("click", (e) => {
+            var divEditorFiltres = document.getElementById("editor-filtres");
+
+            if (divEditorFiltres.style.display === "none" || divEditorFiltres.style.display === "") {
+                divEditorFiltres.style.display = "block";
+            } else {
+                divEditorFiltres.style.display = "none";
+            }
+
+            if (editorFiltres.length === 0) {
+                layer = globalMap.getLibMap().getLayers().getArray()[1]; // ["planign"]
+
+                var filters = layer.get("mapbox-filters").filters;
+                for (var i = 0; i < filters.length; i++) {
+                    var _name = filters[i].filterName;
+                    var _style =  filters[i].style;
+
+                    var label = document.createElement('label');
+                    label.id = "editor-filtres-" + i;
+                    label.className = '';
+                    label.innerHTML = _name; // titre de la 'facette'
+
+                    divEditorFiltres.appendChild(label);
+
+                    // Editeur de filtres
+                    var editor = new ol.style.Editor({
+                        target : divEditorFiltres,
+                        id : i,
+                        style : _style,
+                        tools : {
+                            themes : false,
+                            layers : true,
+                            filter : false,
+                            style : false,
+                            legend : false,
+                            title : true,
+                            group : false,
+                            sort : true, // on trie les filtres afin d'avoir un permalien conforme à la liste des filtres !
+                            title : false,
+                            type : false,
+                            pin : false
+                        },
+                        events : {
+                            "editor:layer:onclickvisibility" : function (e) {
+                                // recherche de l'editeur de style
+                                var editorCurrent = null;
+                                for (var p = 0; p < editorFiltres.length; p++) {
+                                    var _editor = editorFiltres[p];
+                                    var s = _editor.getContainer().innerHTML;
+                                    if (s.indexOf(e.target.srcElement.id) !== -1) {
+                                        editorCurrent = _editor;
+                                    }
+                                }
+                                // on recupere des informations
+                                var data = e.target.data.obj;
+                                var target = e.target.srcElement;
+                                var category = editorCurrent.getStyle().name;
+                                var status = [];
+                                for (var nn = 0; nn < editorCurrent.getLayers().length; nn++) {
+                                    var o = editorCurrent.getLayers()[nn];
+                                    status.push((o.visibility()) ? 1 : 0);
+                                }
+
+                                // choix du filtre
+                                globalMap._updateFilterMapBoxLayer(layer, "planign", {
+                                    data:data,
+                                    active:target.checked,
+                                    category:category,
+                                    status:status
+                                })
+                                .then(function () {
+
+                                })
+                                .catch(function (error) {
+                                    console.error(error);
+                                });
+                            }
+                        }
+                    });
+                    editor.createElement()
+                        .then(function () {
+                            // enregistrement de l'editeur
+                            editorFiltres.push(editor);
+
+                        })
+                }
+            }
+        });
+
+        document.getElementById("button-editor-themes").addEventListener("click", (e) => {
+            var divEditorThemes = document.getElementById("editor-themes");
+
+            if (divEditorThemes.style.display === "none" || divEditorThemes.style.display === "") {
+                divEditorThemes.style.display = "block";
+            } else {
+                divEditorThemes.style.display = "none";
+            }
+
+            if (!editorThemes) {
+                layer = globalMap.getLibMap().getLayers().getArray()[1]; // ["planign"]
+
+                var _styles = layer.get("mapbox-themes").styles;
+                // Editeur de themes
+                editorThemes = new ol.style.Editor({
+                    target : divEditorThemes,
+                    style : _styles[0].url, // le 1er style par defaut...
+                    themes: {
+                        themesSummary : "Styles disponibles", // BUG pour changer le titre !
+                        themes : _styles
+                    },
+                    tools : {
+                        themes : true,
+                        layers : false,
+                        title : true // BUG pour changer le titre !
+                    },
+                    events : {
+                        "editor:themes:onclicktitle" : function (e) {
+                            // on recupere des informations
+                            var url = e.target.srcElement.data;
+                            var file = url.match(/([^\/]+)(?=\.\w+$)/)[1];
+                            var cid = e.target.srcElement.id; // GPEditorMapBoxThemeInput_ID_1_1572098033570
+                            var idx = cid.substring(cid.lastIndexOf("ID_") + 3, cid.lastIndexOf("_")); // 1
+
+                            // changement de themes
+                            globalMap._updateStyleMapBoxLayer(layer, "planign", {url:url, index:idx})
+                            .then(function () {
+
+                            })
+                            .catch(function (error) {
+                                console.error(error);
+                            });
+                        }
+                    }
+                });
+                editorThemes.createElement();
+            }
         });
     </script>
 {{/content}}

--- a/src/Interface/IMapListeners.js
+++ b/src/Interface/IMapListeners.js
@@ -88,7 +88,7 @@ IMap.prototype.listen = function (eventId, action, context) {
         this.logger.error("no action provided for the event : " + eventId);
         return false;
     }
-    // FIXME: Invalid typeof comparison value. (valid-typeof)
+    // FIXME: Invalid typeof comparison value. (valid-typeof) ?
     if (!action.name || typeof action.name === "anomynous") {
         this.logger.error("the action provided for the event : " + eventId + " must be named");
         return false;

--- a/src/Interface/IMapListeners.js
+++ b/src/Interface/IMapListeners.js
@@ -88,7 +88,8 @@ IMap.prototype.listen = function (eventId, action, context) {
         this.logger.error("no action provided for the event : " + eventId);
         return false;
     }
-    if ( !action.name || typeof action.name === "anomynous") {
+    // FIXME: Invalid typeof comparison value. (valid-typeof)
+    if (!action.name || typeof action.name === "anomynous") {
         this.logger.error("the action provided for the event : " + eventId + " must be named");
         return false;
     }
@@ -223,11 +224,11 @@ IMap.prototype.forgetAllListeners = function () {
         // the array is spliced while looping it,
         // all registered listeners are deleted looping on the first array item
         var i = 0;
-        while (map._events[listeners].length > 0) {
-            map.forget(listeners, map._events[listeners][i].action);
+        while (this._events[listeners].length > 0) {
+            this.forget(listeners, this._events[listeners][i].action);
         }
     }
-}
+};
 
 /**
  * Ecouteur de changements sur les couches pour gerer le tableau this._layers.

--- a/src/Itowns/ItMapBase.js
+++ b/src/Itowns/ItMapBase.js
@@ -139,6 +139,6 @@ ItMap.prototype.destroyMap = function () {
     while (this.div.firstChild) {
         this.div.removeChild(this.div.firstChild);
     }
-}
+};
 
 export { ItMap };

--- a/src/Map.js
+++ b/src/Map.js
@@ -205,7 +205,7 @@ var mapLoadedEvent = {
  * | markersOptions | Array.<{@link Gp.MarkerOptions Gp.MarkerOptions}> | optional | | Options for displaying markers on the map. |
  * | projection | String | optional | "EPSG:3857" | Projection code (in EPSG or IGNF register) for the map. Not available in 3D as the projection is always "EPSG:4326" |
  * | extent | Array | optional | | Forced extent of the view, with the format [west, south, east, north], with the projection of the map
- * 
+ *
  * * **Specific 3D options**
  *
  * | property | Type | Argument | Default | Description |

--- a/src/OpenLayers/OlMapBase.js
+++ b/src/OpenLayers/OlMapBase.js
@@ -87,7 +87,7 @@ OlMap.prototype.destroyMap = function () {
     // 1 - suppression de tous les listeners
     this.forgetAllListeners();
     // 2 - suppression de la div
-    map.libMap.setTarget(null);
-}
+    this.libMap.setTarget(null);
+};
 
 export { OlMap };

--- a/src/OpenLayers/OlMapListeners.js
+++ b/src/OpenLayers/OlMapListeners.js
@@ -75,7 +75,7 @@ OlMap.prototype.listen = function (eventId, action, context) {
                     newZoom : this._getZoomFromResolution(this.libMap.getView().getResolution()/* , "EPSG:4326" */)
                 });
             }.bind(this);
-            olEventKey = this.libMap.getView().on("change:resolution", callbackZoomchange );
+            olEventKey = this.libMap.getView().on("change:resolution", callbackZoomchange);
             break;
         case "azimuthChanged" :
             var callbackAzimuthChange = function (olEvt) {
@@ -84,7 +84,7 @@ OlMap.prototype.listen = function (eventId, action, context) {
                     newAzimuth : this.libMap.getView().getRotation() * 180 / Math.PI
                 });
             }.bind(this);
-            olEventKey = this.libMap.getView().on("change:rotation", callbackAzimuthChange );
+            olEventKey = this.libMap.getView().on("change:rotation", callbackAzimuthChange);
             break;
         case "tiltChanged" :
             // non pertinent en 2D
@@ -106,7 +106,7 @@ OlMap.prototype.listen = function (eventId, action, context) {
                     position : ladded.getZIndex()
                 });
             }.bind(this);
-            olEventKey = this.libMap.getLayers().on("add", callbackLayerAdded );
+            olEventKey = this.libMap.getLayers().on("add", callbackLayerAdded);
             this._registerEvent(olEventKey, eventId, action, context);
 
             // abonnement à un retrait de couche
@@ -126,9 +126,9 @@ OlMap.prototype.listen = function (eventId, action, context) {
                     layerRemoved : layerOpts
                 });
             }.bind(this);
-            olEventKey = this.libMap.getLayers().on("remove", callbackLayerRemoved );
+            olEventKey = this.libMap.getLayers().on("remove", callbackLayerRemoved);
             this._registerEvent(olEventKey, eventId, action, context);
-            
+
             // abonnement à un changement de propriete sur chaque couche
             for (var obsProperty in OlMap.LAYERPROPERTIES) {
                 map.logger.trace("[OlMap] listen : abonnement layerProperty : " + obsProperty);
@@ -165,7 +165,7 @@ OlMap.prototype.listen = function (eventId, action, context) {
                                 newValue : newCommonProp[OlMap.LAYERPROPERTIES[olEvt.key]],
                                 layerChanged : layerOpts
                             });
-                        }
+                        };
 
                         olEventKey = olLayer.on("change:" + obsProperty, callbackLayerChanged);
                         this._registerEvent(olEventKey, eventId, action, context);

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -1610,9 +1610,6 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                         // ajout du layer sur la carte
                                         map.addLayer(p.layer);
 
-                                        // etat des layers en cours
-                                        self.logger.warn(p.layer, self._layers);
-
                                         // FIXME
                                         // le tilejson est async donc les informations ne sont pas encore disponibles
                                         // pour les properties mapbox-*

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -823,47 +823,62 @@ OlMap.MAPBOXPROPERTIES = {
 
 /**
 * callback sur la propriété observable : mapbox-filters
-* @param {Object} e - {type, target} layer
+* contexte (this) est un objet Gp.Map
+* @param {Object} e - {type, target, old, key} layer
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableFilters = function (e) {
-    // console.error("DEBUG:ObservableFilters", e, this.get(OlMap.MAPBOXPROPERTIES["filters"]));
+    this.logger.error("DEBUG:ObservableFilters", e, e.target.get(OlMap.MAPBOXPROPERTIES["filters"]));
 };
 
 /**
 * callback sur la propriété observable : mapbox-status
-* @param {Object} e - {type, target} layer
+* contexte (this) est un objet Gp.Map
+* @param {Object} e - {type, target, old, key} layer
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableStatus = function (e) {
-    // console.error("DEBUG:ObservableStatus", e, this.get(OlMap.MAPBOXPROPERTIES["status"]));
+    this.logger.error("DEBUG:ObservableStatus", e, e.target.get(OlMap.MAPBOXPROPERTIES["status"]));
 };
 
 /**
 * callback sur la propriété observable : mapbox-themes
-* @param {Object} e - {type, target} layer
+* contexte (this) est un objet Gp.Map
+* @param {Object} e -{type, target, old, key} layer
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableThemes = function (e) {
-    // console.error("DEBUG:ObservableThemes", e, this.get(OlMap.MAPBOXPROPERTIES["themes"]));
+    this.logger.error("DEBUG:ObservableThemes", e, e.target.get(OlMap.MAPBOXPROPERTIES["themes"]));
 };
 
 /**
-* callback sur la propriété observable : mapbox-styles
-* @param {Object} e - {type, target} layer
+* callback sur la propriété observable sur la couche : mapbox-styles
+* contexte (this) est un objet Gp.Map
+* @param {Object} e - {type, target, old, key} layer
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableStyles = function (e) {
-    // console.error("DEBUG:ObservableStyles", e, this.get(OlMap.MAPBOXPROPERTIES["styles"]));
+    this.logger.error("DEBUG:ObservableStyles", e, e.target.get(OlMap.MAPBOXPROPERTIES["styles"]));
+};
+
+/**
+* callback sur la propriété observable sur la carte : mapbox-styles
+* contexte (this) est un objet Gp.Map
+* @param {Object} e - {type, target, old, key} map
+* @private
+*/
+OlMap.prototype._callbackMapBoxObservableMapStyles = function (e) {
+    this.logger.error("DEBUG:ObservableMapStyles", e, e.target.get(OlMap.MAPBOXPROPERTIES["styles"]));
 };
 
 /**
 * callback sur la propriété observable : mapbox-extensions
-* @param {Object} e - {type, target} layer
+* contexte (this) est un objet Gp.Map
+* @param {Object} e - {type, target, old, key} layer
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableExtensions = function (e) {
-    // console.error("DEBUG:ObservableExtensions", e, this.get(OlMap.MAPBOXPROPERTIES["extensions"]));
+    this.logger.error("DEBUG:ObservableExtensions", e, e.target.get(OlMap.MAPBOXPROPERTIES["extensions"]));
 };
 
 /******************************************************************************
@@ -1244,7 +1259,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                     // eventuelle (ex. editeur)
                                                     // > map.set("mapbox-extensions")
                                                     vectorLayer.set(OlMap.MAPBOXPROPERTIES["extensions"], tileJSONContent);
-                                                    vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["extensions"], self._callbackMapBoxObservableExtensions);
+                                                    vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["extensions"], self._callbackMapBoxObservableExtensions.bind(self));
                                                     // debug
                                                     vectorLayer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["extensions"]);
 
@@ -1609,7 +1624,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                         var _allStyles = map.get(OlMap.MAPBOXPROPERTIES["styles"]) || {};
                                         _allStyles[_id] = p.styles;
                                         map.set(OlMap.MAPBOXPROPERTIES["styles"], _allStyles);
-                                        map.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableStyles);
+                                        map.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableMapStyles.bind(self));
                                         // debug
                                         map.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["styles"]);
 
@@ -1637,7 +1652,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             }
                                         }
                                         p.layer.set(OlMap.MAPBOXPROPERTIES["styles"], _stylesClone);
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableStyles);
+                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableStyles.bind(self));
                                         // debug
                                         p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["styles"]);
 
@@ -1648,7 +1663,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             stylesSummary : p.options.stylesSummary,
                                             styles : p.options.styles
                                         });
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["themes"], self._callbackMapBoxObservableThemes);
+                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["themes"], self._callbackMapBoxObservableThemes.bind(self));
                                         // debug
                                         p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["themes"]);
 
@@ -1659,7 +1674,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             filtersSummary : p.options.filtersSummary,
                                             filters : p.options.filters
                                         });
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["filters"], self._callbackMapBoxObservableFilters);
+                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["filters"], self._callbackMapBoxObservableFilters.bind(self));
                                         // debug
                                         p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["filters"]);
 
@@ -1675,7 +1690,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             "layers" : p.selectedLayers, // TODO !
                                             "filters" : p.selectedFilters
                                         });
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["status"], self._callbackMapBoxObservableStatus);
+                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["status"], self._callbackMapBoxObservableStatus.bind(self));
                                         // debug
                                         p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["status"]);
 
@@ -1811,7 +1826,7 @@ OlMap.prototype._updateStyleMapBoxLayer = function (layer, id, options) {
                                 var _extensions = layer.get(OlMap.MAPBOXPROPERTIES["extensions"]);
                                 var _urls = layer.getSource().urls;
                                 var _filters = layer.get(OlMap.MAPBOXPROPERTIES["filters"]);
-                                var _styles = map.get(OlMap.MAPBOXPROPERTIES["styles"]) || {};
+                                var _styles = JSON.parse(JSON.stringify(map.get(OlMap.MAPBOXPROPERTIES["styles"]))) || {};
                                 var _style = Object.assign({}, style); // clone
                                 _styles[id] = _createCustomFiltersStyles(
                                     source,
@@ -1827,7 +1842,7 @@ OlMap.prototype._updateStyleMapBoxLayer = function (layer, id, options) {
                                 // maj au même moment que MAPBOXPROPERTIES["styles"] !
                                 // si on change de theme, il faut donc mettre à jour
                                 // les styles attributaires
-                                var _filters = layer.get(OlMap.MAPBOXPROPERTIES["filters"]);
+                                var _filters = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["filters"])));
                                 if (_filters) {
                                     layer.set(OlMap.MAPBOXPROPERTIES["filters"], _filters);
                                 }
@@ -1836,7 +1851,7 @@ OlMap.prototype._updateStyleMapBoxLayer = function (layer, id, options) {
                                 // maj des themes : mapbox-themes
                                 // si on change de theme, il faut donc mettre à jour
                                 // le theme selectionné
-                                var _themes = layer.get(OlMap.MAPBOXPROPERTIES["themes"]);
+                                var _themes = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["themes"])));
                                 if (_themes) {
                                     for (var i = 0; i < _themes.styles.length; i++) {
                                         var t = _themes.styles[i];
@@ -1847,7 +1862,7 @@ OlMap.prototype._updateStyleMapBoxLayer = function (layer, id, options) {
                                             t.selected = true;
                                         }
                                     }
-                                    layer.set(OlMap.MAPBOXPROPERTIES["themes"], _themes); // FIXME ce listeners ne se lance pas !?
+                                    layer.set(OlMap.MAPBOXPROPERTIES["themes"], _themes);
                                 }
                             })
                             .then(function () {
@@ -1855,16 +1870,18 @@ OlMap.prototype._updateStyleMapBoxLayer = function (layer, id, options) {
                                 // si on change de theme, il faut donc mettre à jour
                                 // le theme (index et id) ainsi que le statut des filtres
                                 // sélectionnés
-                                var _filters = layer.get(OlMap.MAPBOXPROPERTIES["filters"]);
-                                var _status = layer.get(OlMap.MAPBOXPROPERTIES["status"]);
+                                var _filters = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["filters"])));
+                                var _status = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["status"])));
                                 if (_status) {
                                     var filters = [];
-                                    for (var n = 0; n < _filters["filters"].length; n++) {
-                                        var f = _filters["filters"][n];
-                                        filters.push({
-                                            k : f.filterName,
-                                            v : (f.configuration && f.configuration.selected) ? f.configuration.selected : []
-                                        });
+                                    if (_filters["filters"]) {
+                                        for (var n = 0; n < _filters["filters"].length; n++) {
+                                            var f = _filters["filters"][n];
+                                            filters.push({
+                                                k : f.filterName,
+                                                v : (f.configuration && f.configuration.selected) ? f.configuration.selected : []
+                                            });
+                                        }
                                     }
                                     var o = {
                                         "theme" : {
@@ -2098,20 +2115,22 @@ OlMap.prototype._updateFilterMapBoxLayer = function (layer, id, options) {
             // maj des styles attributaires du layer : mapbox-filters
             // si on change la visibilité, il faut donc mettre à jour les styles
             // attributaires
-            var _filters = layer.get(OlMap.MAPBOXPROPERTIES["filters"]);
+            var _filters = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["filters"])));
             if (_filters) {
-                for (var i = 0; i < _filters.filters.length; i++) {
-                    var _f = _filters.filters[i];
-                    if (_f.filterName === options.category) {
-                        if (_f.configuration && _f.configuration.selected) {
-                            _f.configuration.selected = options.status;
-                        } else {
-                            _f.configuration = {
-                                selected : options.status,
-                                type : 0
-                            };
+                if (_filters.filters) {
+                    for (var i = 0; i < _filters.filters.length; i++) {
+                        var _f = _filters.filters[i];
+                        if (_f.filterName === options.category) {
+                            if (_f.configuration && _f.configuration.selected) {
+                                _f.configuration.selected = options.status;
+                            } else {
+                                _f.configuration = {
+                                    selected : options.status,
+                                    type : 0
+                                };
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
                 layer.set(OlMap.MAPBOXPROPERTIES["filters"], _filters);
@@ -2134,7 +2153,7 @@ OlMap.prototype._updateFilterMapBoxLayer = function (layer, id, options) {
             // maj du statut : mapbox-status
             // si on change la visibilité, il faut donc mettre à jour le statut
             // des filtres
-            var _status = layer.get(OlMap.MAPBOXPROPERTIES["status"]);
+            var _status = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["status"])));
             if (_status) {
                 // [{k:categorie1, v: [0,1,0,1]},{k:categorie2, v:[0,0,0,0]}]
                 for (var m = 0; m < _status.filters.length; m++) {

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -471,7 +471,7 @@ var _createCustomFilterStyle = function (source, urls, filter, tilejson, stylejs
 
                         if (!_mtdLayersId) {
                             // eslint-disable-next-line no-console
-                            console.warn("Filtres utilisateurs : auncune association possible !?");
+                            console.warn("Filtres utilisateurs : auncune association possible (" + filter.filterName + ") !?");
                             break;
                         }
 
@@ -483,7 +483,7 @@ var _createCustomFilterStyle = function (source, urls, filter, tilejson, stylejs
                         // car trop de valeurs..., du coup, on ne peut pas gerer ce type d'informations.
                         if (!_tjsonvalues) {
                             // eslint-disable-next-line no-console
-                            console.warn("Filtres utilisateurs : auncune valeurs !?");
+                            console.warn("Filtres utilisateurs : auncune valeurs (" + filter.filterName + ") !?");
                             continue;
                         }
 
@@ -611,7 +611,7 @@ var _createCustomFilterStyle = function (source, urls, filter, tilejson, stylejs
 
     if (_style.layers.length === 0) {
         // eslint-disable-next-line no-console
-        console.warn("Filtres utilisateurs : aucun 'layers' !?");
+        console.warn("Filtres utilisateurs : aucun 'layers' (" + filter.filterName + ") !?");
     }
 
     /* Exemple de style json pour un filtre attributaire (ex. Nature) :
@@ -687,14 +687,13 @@ var _createCustomFiltersStyles = function (source, urls, filters, tilejson, styl
             var _filter = filters[ii];
 
             var _conf = _filter.configuration || {};
-
             // filtre courant
             var filter = {
                 tableName : null, // recherche sur une table : ex. "table.champ"
                 propertyName : _filter.propertyName,
                 filterName : _filter.filterName,
-                selected : (_conf) ? _conf.selected : [],
-                type : (_conf) ? _conf.type : 0
+                selected : (_conf && _conf.selected) ? _conf.selected : [],
+                type : (_conf && _conf.type) ? _conf.type : 0
             };
 
             // le champ "propertyName" contient il le nom d'une table ?
@@ -818,7 +817,8 @@ OlMap.MAPBOXPROPERTIES = {
     styles : "mapbox-styles",
     layers : "mapbox-layers", // property internal to olms
     source : "mapbox-source", // property internal to olms
-    extensions : "mapbox-extensions"
+    extensions : "mapbox-extensions",
+    loaded : "mapbox-loaded"
 };
 
 /**
@@ -828,7 +828,7 @@ OlMap.MAPBOXPROPERTIES = {
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableFilters = function (e) {
-    this.logger.error("DEBUG:ObservableFilters", e, e.target.get(OlMap.MAPBOXPROPERTIES["filters"]));
+    this.logger.warn("DEBUG:ObservableFilters", e, e.target.get(OlMap.MAPBOXPROPERTIES["filters"]));
 };
 
 /**
@@ -838,7 +838,7 @@ OlMap.prototype._callbackMapBoxObservableFilters = function (e) {
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableStatus = function (e) {
-    this.logger.error("DEBUG:ObservableStatus", e, e.target.get(OlMap.MAPBOXPROPERTIES["status"]));
+    this.logger.warn("DEBUG:ObservableStatus", e, e.target.get(OlMap.MAPBOXPROPERTIES["status"]));
 };
 
 /**
@@ -848,7 +848,7 @@ OlMap.prototype._callbackMapBoxObservableStatus = function (e) {
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableThemes = function (e) {
-    this.logger.error("DEBUG:ObservableThemes", e, e.target.get(OlMap.MAPBOXPROPERTIES["themes"]));
+    this.logger.warn("DEBUG:ObservableThemes", e, e.target.get(OlMap.MAPBOXPROPERTIES["themes"]));
 };
 
 /**
@@ -858,7 +858,7 @@ OlMap.prototype._callbackMapBoxObservableThemes = function (e) {
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableStyles = function (e) {
-    this.logger.error("DEBUG:ObservableStyles", e, e.target.get(OlMap.MAPBOXPROPERTIES["styles"]));
+    this.logger.warn("DEBUG:ObservableStyles", e, e.target.get(OlMap.MAPBOXPROPERTIES["styles"]));
 };
 
 /**
@@ -868,7 +868,7 @@ OlMap.prototype._callbackMapBoxObservableStyles = function (e) {
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableMapStyles = function (e) {
-    this.logger.error("DEBUG:ObservableMapStyles", e, e.target.get(OlMap.MAPBOXPROPERTIES["styles"]));
+    this.logger.warn("DEBUG:ObservableMapStyles", e, e.target.get(OlMap.MAPBOXPROPERTIES["styles"]));
 };
 
 /**
@@ -878,7 +878,17 @@ OlMap.prototype._callbackMapBoxObservableMapStyles = function (e) {
 * @private
 */
 OlMap.prototype._callbackMapBoxObservableExtensions = function (e) {
-    this.logger.error("DEBUG:ObservableExtensions", e, e.target.get(OlMap.MAPBOXPROPERTIES["extensions"]));
+    this.logger.warn("DEBUG:ObservableExtensions", e, e.target.get(OlMap.MAPBOXPROPERTIES["extensions"]));
+};
+
+/**
+* callback sur la propriété observable : mapbox-loaded
+* contexte (this) est un objet Gp.Map
+* @param {Object} e - {type, target, old, key} layer
+* @private
+*/
+OlMap.prototype._callbackMapBoxObservableLoaded = function (e) {
+    this.logger.warn("DEBUG:ObservableLoaded", e, e.target.get(OlMap.MAPBOXPROPERTIES["loaded"]));
 };
 
 /******************************************************************************
@@ -1008,6 +1018,8 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                 var vectorSource = null;
                                 // couche ol
                                 var vectorLayer = null;
+                                // tilejson ou metadata.json
+                                var vectorTileJson = null;
 
                                 if (_glSources.hasOwnProperty(_glSourceId)) {
                                     var _title = "";
@@ -1235,22 +1247,32 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                 declutter : true // utile ? option ?
                                             });
                                             vectorLayer.id = _glSourceId;
-                                            var vectorTileJson = new TileJSONSource({
+                                            vectorTileJson = new TileJSONSource({
                                                 url : _glUrl
                                             });
-                                            // FIXME pb async !
+
+                                            // on enregistre le statut du chargement du tilejson
+                                            // > map.set("mapbox-loaded")
+                                            vectorLayer.set(OlMap.MAPBOXPROPERTIES["loaded"], false);
+                                            vectorLayer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["loaded"]);
+                                            vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["loaded"], self._callbackMapBoxObservableLoaded.bind(self));
+
                                             // lecture du tilejson avec extension IGN,
                                             // les extensions sont enregistrées
                                             // dans les propriétés de la couche : layer.set(mapbox-extensions)
                                             // pour une utilisation ulterieur (ex. editeur)
                                             var _key = vectorTileJson.on("change", function (e) {
                                                 if (vectorTileJson.getState() === "error") {
-                                                    // FIXME Exception ou message ?
+                                                    // FIXME Exception ou message console ?
                                                     // l'exception est trop brutale...,
                                                     // elle bloque l'afffichage des données !
-                                                    // throw new Error("HTTP TileJSON error (metadata.json)");
+                                                    //  throw new Error("HTTP TileJSON error (metadata.json)");
+
                                                     // eslint-disable-next-line no-console
                                                     console.error("HTTP TileJSON error (metadata.json)");
+
+                                                    // fin du chargement du tilejson..., même si mauvaise fin...
+                                                    vectorLayer.set(OlMap.MAPBOXPROPERTIES["loaded"], true);
                                                 }
                                                 if (vectorTileJson.getState() === "ready") {
                                                     var tileJSONContent = vectorTileJson.getTileJSON();
@@ -1298,20 +1320,18 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                     // les filtres sont ajoutés directement dans l'objet _glStyle.
                                                     // on peut aussi gérer les filtres sélectionnés.
                                                     if (Array.isArray(layerOpts.filters)) {
-                                                        // on clone les options car on ne veut pas les modifier
-                                                        var _filterOptionsClone = JSON.parse(JSON.stringify(layerOpts.filters)); // clone
                                                         // on boucle sur les filtres utilisateurs
-                                                        for (var ii = 0; ii < _filterOptionsClone.length; ii++) {
-                                                            var _filterOptions = _filterOptionsClone[ii];
+                                                        for (var ii = 0; ii < layerOpts.filters.length; ii++) {
+                                                            var _refLayerOptsFilter = layerOpts.filters[ii];
 
-                                                            var _conf = _filterOptions.configuration || {};
-                                                            var _selected = (_conf) ? _conf.selected : [];
-                                                            var _type = (_conf) ? _conf.type : 0;
+                                                            var _conf = _refLayerOptsFilter.configuration || {};
+                                                            var _selected = (_conf && _conf.selected) ? _conf.selected : [];
+                                                            var _type = (_conf && _conf.type) ? _conf.type : 0;
                                                             // filtre courant
                                                             var _filter = {
                                                                 tableName : null, // recherche sur une table : ex. "table.champ"
-                                                                propertyName : _filterOptions.propertyName,
-                                                                filterName : _filterOptions.filterName,
+                                                                propertyName : _refLayerOptsFilter.propertyName,
+                                                                filterName : _refLayerOptsFilter.filterName,
                                                                 selected : _selected,
                                                                 type : _type
                                                             };
@@ -1331,23 +1351,17 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                                 _urls = vectorLayer.getSource().urls;
                                                             }
 
-                                                            // la source courante (id)
-                                                            var _source = _glSourceId;
-
-                                                            // les styles (json)
-                                                            var _styles = _glStyle;
-
                                                             // le tileJSON (json)
                                                             var _tjson = tileJSONContent;
 
                                                             // on créé les styles (json) pour le filtre utilisateur courant.
                                                             // cf. fonction _createCustomFilterStyle() pour plus d'informations
                                                             var _filterStyle = _createCustomFilterStyle(
-                                                                _source, // id de la source
+                                                                _glSourceId, // id de la source courante
                                                                 _urls, // urls des services
                                                                 _filter, // filtre : objet
                                                                 _tjson, // "metadata.json"
-                                                                _styles // style json complet
+                                                                _glStyle // style json complet
                                                             );
 
                                                             // some entries ?
@@ -1384,15 +1398,15 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                             // (multisource === plusieurs couches !)
                                                             // pour une utilisation eventuelle (ex. editeur)
                                                             // > layer.set("mapbox-styles")
-                                                            var _stylesClone = JSON.parse(JSON.stringify(_styles)); // clone
-                                                            var _layers = _stylesClone.layers;
+                                                            var _cloneStyle = JSON.parse(JSON.stringify(_glStyle)); // clone
+                                                            var _layers = _cloneStyle.layers;
                                                             for (var a = 0; a < _layers.length; a++) {
                                                                 var _layer = _layers[a];
                                                                 // FIXME
                                                                 // on ecarte les sources differentes : 1 source = 1 layer
                                                                 // mais si on a du multi source, en surpprimant des entrées, on risque
                                                                 // de rendre les indexes foireux !
-                                                                if (_layer.source !== _source) {
+                                                                if (_layer.source !== _glSourceId) {
                                                                     _layers.splice(a, 1);
                                                                     a--;
                                                                     continue;
@@ -1406,32 +1420,36 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                                     continue;
                                                                 }
                                                             }
-                                                            vectorLayer.set(OlMap.MAPBOXPROPERTIES["styles"], _stylesClone);
+                                                            vectorLayer.set(OlMap.MAPBOXPROPERTIES["styles"], _cloneStyle);
 
                                                             // on ajoute les styles créés à partir du filtre attributaire
                                                             // dans le style principale
                                                             // utile !?
                                                             for (var kk = 0; kk < _filterStyle.layers.length; kk++) {
-                                                                // FIXME
+                                                                // Cas particulier :
                                                                 // si les filtres et les "layers" portent le même identifiant,
                                                                 // l'ajout des filtres va automatiquement doublonner
                                                                 // la properties interne : "mapbox-layers"
-                                                                _styles.layers.push(_filterStyle.layers[kk]);
+                                                                _glStyle.layers.push(_filterStyle.layers[kk]); // on modifie le style principale !
                                                             }
 
                                                             // on se garde sous le coude le style brute pour un filtre attributaire,
                                                             // ce style sera archivé dans la properties "mapbox-filters"...
-                                                            _filterOptions.style = _filterStyle;
+                                                            _refLayerOptsFilter.style = _filterStyle;
                                                         }
                                                         // ajout des differents filtres attributaires de la couche
                                                         // pour une utilisation eventuelle (ex. portail ou editeur)
                                                         // > layer.set("mapbox-filters")
                                                         vectorLayer.set(OlMap.MAPBOXPROPERTIES["filters"], {
                                                             filtersSummary : layerOpts.filtersSummary,
-                                                            filters : _filterOptionsClone
+                                                            filters : layerOpts.filters
                                                         });
                                                     }
 
+                                                    // fin du chargement du tilejson
+                                                    vectorLayer.set(OlMap.MAPBOXPROPERTIES["loaded"], true);
+
+                                                    // desabonnement
                                                     olObservableUnByKey(_key);
                                                 }
                                             });
@@ -1471,273 +1489,286 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                         return; // FIXME promise ?
                                     }
 
-                                    // FIXME gestion du zIndex (option position) sur du multi-source !?
+                                    // les abonnements sur la couche
+                                    vectorLayer.set(OlMap.MAPBOXPROPERTIES["themes"], {});
+                                    vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["themes"], self._callbackMapBoxObservableThemes.bind(self));
+                                    vectorLayer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["themes"]);
 
-                                    // parametre à transmettre à la fonction auto-invoquée
-                                    var params = {
-                                        id : _glSourceId,
-                                        styles : _glStyle,
-                                        layer : vectorLayer,
-                                        selectedTheme : _selectedTheme,
-                                        selectedFilters : _selectedFilters,
-                                        selectedLayers : _selectedLayers,
-                                        // ce n'est pas très dynamique comme manière de faire passer les options !
-                                        options : {
-                                            visibility : layerOpts.visibility,
-                                            queryable : _queryable,
-                                            opacity : layerOpts.opacity,
-                                            grayScaled : layerOpts.grayScaled,
-                                            position : _position,
-                                            zoomToExtent : layerOpts.zoomToExtent,
-                                            url : layerOpts.url,
-                                            defaultStyleName : layerOpts.defaultStyleName,
-                                            defaultStyleThumbnail : layerOpts.defaultStyleThumbnail,
-                                            defaultStyleDescription : layerOpts.defaultStyleDescription,
-                                            format : layerOpts.format,
-                                            mapboxOptions : layerOpts.mapboxOptions,
-                                            stylesSummary : layerOpts.stylesSummary,
-                                            styles : _themes,
-                                            filtersSummary : layerOpts.filtersSummary,
-                                            filters : _filters,
-                                            title : _title,
-                                            description : _description,
-                                            quicklookUrl : _quicklookUrl,
-                                            metadata : _metadata,
-                                            legends : _legends,
-                                            originators : _originators
-                                        }
-                                    };
-                                    // fonction auto-invoquée
-                                    (function (p) {
-                                        // FIXME faut il ajouter le style de type background ?
-                                        // fonction de style de la couche
-                                        var setStyle = function () {
-                                            applyStyleOlms(p.layer, p.styles, p.id)
-                                                .then(function () {
-                                                    // gestion de la visibilité
-                                                    var visibility = (typeof layerOpts.visibility === "undefined") ? true : layerOpts.visibility;
-                                                    p.layer.setVisible(visibility);
-                                                    p.layer.setOpacity(layerOpts.opacity || 1);
-                                                })
-                                                .then(function () {
-                                                    var zoomToExtent = p.options.zoomToExtent || false;
-                                                    if (zoomToExtent) {
-                                                        // zoom sur l'étendue avec l'option zoomToExtent
-                                                        var source = p.layer.getSource();
-                                                        if (map.getView() && source && source.getExtent) {
-                                                            var key = source.on("change", function () {
-                                                                var _sourceExtent = source.getExtent();
-                                                                var _stateExtent = source.getState();
-                                                                if (_stateExtent === "ready" && _sourceExtent[0] !== Infinity) {
-                                                                    olObservableUnByKey(key);
-                                                                    map.getView().fit(_sourceExtent, {
-                                                                        maxZoom : 18
+                                    vectorLayer.set(OlMap.MAPBOXPROPERTIES["styles"], {});
+                                    vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableStyles.bind(self));
+                                    vectorLayer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["styles"]);
+
+                                    vectorLayer.set(OlMap.MAPBOXPROPERTIES["filters"], {});
+                                    vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["filters"], self._callbackMapBoxObservableFilters.bind(self));
+                                    vectorLayer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["filters"]);
+
+                                    vectorLayer.set(OlMap.MAPBOXPROPERTIES["status"], {});
+                                    vectorLayer.on("change:" + OlMap.MAPBOXPROPERTIES["status"], self._callbackMapBoxObservableStatus.bind(self));
+                                    vectorLayer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["status"]);
+
+                                    // Lancement !
+                                    var launch = function () {
+                                        // parametre à transmettre à la fonction auto-invoquée
+                                        var params = {
+                                            id : _glSourceId,
+                                            styles : _glStyle,
+                                            layer : vectorLayer,
+                                            selectedTheme : _selectedTheme,
+                                            selectedFilters : _selectedFilters,
+                                            selectedLayers : _selectedLayers,
+                                            // ce n'est pas très dynamique comme manière de faire passer les options !
+                                            options : {
+                                                visibility : layerOpts.visibility,
+                                                queryable : _queryable,
+                                                opacity : layerOpts.opacity,
+                                                grayScaled : layerOpts.grayScaled,
+                                                position : _position, // FIXME : gestion du zIndex (option position) sur du multi-source !?
+                                                zoomToExtent : layerOpts.zoomToExtent,
+                                                url : layerOpts.url,
+                                                defaultStyleName : layerOpts.defaultStyleName,
+                                                defaultStyleThumbnail : layerOpts.defaultStyleThumbnail,
+                                                defaultStyleDescription : layerOpts.defaultStyleDescription,
+                                                format : layerOpts.format,
+                                                mapboxOptions : layerOpts.mapboxOptions,
+                                                stylesSummary : layerOpts.stylesSummary,
+                                                styles : _themes,
+                                                filtersSummary : layerOpts.filtersSummary,
+                                                filters : _filters,
+                                                title : _title,
+                                                description : _description,
+                                                quicklookUrl : _quicklookUrl,
+                                                metadata : _metadata,
+                                                legends : _legends,
+                                                originators : _originators
+                                            }
+                                        };
+                                        // fonction auto-invoquée
+                                        (function (p) {
+                                            // FIXME faut il ajouter le style de type background ?
+                                            // fonction de style de la couche
+                                            var setStyle = function () {
+                                                applyStyleOlms(p.layer, p.styles, p.id)
+                                                    .then(function () {
+                                                        // gestion de la visibilité
+                                                        var visibility = (typeof layerOpts.visibility === "undefined") ? true : layerOpts.visibility;
+                                                        p.layer.setVisible(visibility);
+                                                        p.layer.setOpacity(layerOpts.opacity || 1);
+                                                    })
+                                                    .then(function () {
+                                                        var zoomToExtent = p.options.zoomToExtent || false;
+                                                        if (zoomToExtent) {
+                                                            // zoom sur l'étendue avec l'option zoomToExtent
+                                                            var source = p.layer.getSource();
+                                                            if (map.getView() && source && source.getExtent) {
+                                                                var key = source.on("change", function () {
+                                                                    var _sourceExtent = source.getExtent();
+                                                                    var _stateExtent = source.getState();
+                                                                    if (_stateExtent === "ready" && _sourceExtent[0] !== Infinity) {
+                                                                        olObservableUnByKey(key);
+                                                                        map.getView().fit(_sourceExtent, {
+                                                                            maxZoom : 18
+                                                                        });
+                                                                    }
+                                                                });
+                                                                setTimeout(function () {
+                                                                    source.dispatchEvent("change");
+                                                                }, 100);
+                                                            } else {
+                                                                // gestion du centre de la cate si center renseigné !
+                                                                var projCode = map.getView().getProjection().getCode();
+                                                                if (map.getView() && p.styles.center && p.styles.center.length) {
+                                                                    map.getView().setCenter(olTransformProj(p.styles.center, "EPSG:4326", projCode));
+                                                                }
+                                                                // gestion du zoom sur la carte si zoom renseigné !
+                                                                if (map.getView() && (p.styles.zoom || p.styles.zoom === 0)) {
+                                                                    map.getView().setZoom(p.styles.zoom);
+                                                                }
+                                                            }
+                                                        }
+                                                    })
+                                                    .then(function () {
+                                                        // gestion du GFI
+                                                        // l'option 'queryable' ne fonctionne que si le controle GFI est
+                                                        // present sur la carte..., et actif !
+                                                        var GfiControl = self.getLibMapControl("GetFeatureInfo");
+                                                        if (GfiControl && GfiControl.isActive()) {
+                                                            var gfiLayers = GfiControl.getLayers();
+                                                            // par defaut, le controle GFI ne devrait pas ajouter pas les couches
+                                                            // vecteurs dans sa liste de couches requetables...
+                                                            // si on renseigne queryable:true, on doit ajouter cette couche de la liste...
+                                                            // mais, on verifie qu'elle n'exsite pas déjà !
+                                                            if (p.options.queryable === true) {
+                                                                var bfound = false;
+                                                                for (var i = 0; i < gfiLayers.length; i++) {
+                                                                    if (gfiLayers[i].obj === p.layer) {
+                                                                        bfound = true;
+                                                                    }
+                                                                }
+                                                                if (!bfound) {
+                                                                    gfiLayers.push({
+                                                                        obj : p.layer,
+                                                                        event : "singleclick",
+                                                                        infoFormat : "" // peu importe !?
                                                                     });
                                                                 }
-                                                            });
-                                                            setTimeout(function () {
-                                                                source.dispatchEvent("change");
-                                                            }, 100);
-                                                        } else {
-                                                            // gestion du centre de la cate si center renseigné !
-                                                            var projCode = map.getView().getProjection().getCode();
-                                                            if (map.getView() && p.styles.center && p.styles.center.length) {
-                                                                map.getView().setCenter(olTransformProj(p.styles.center, "EPSG:4326", projCode));
                                                             }
-                                                            // gestion du zoom sur la carte si zoom renseigné !
-                                                            if (map.getView() && (p.styles.zoom || p.styles.zoom === 0)) {
-                                                                map.getView().setZoom(p.styles.zoom);
-                                                            }
-                                                        }
-                                                    }
-                                                })
-                                                .then(function () {
-                                                    // gestion du GFI
-                                                    // l'option 'queryable' ne fonctionne que si le controle GFI est
-                                                    // present sur la carte..., et actif !
-                                                    var GfiControl = self.getLibMapControl("GetFeatureInfo");
-                                                    if (GfiControl && GfiControl.isActive()) {
-                                                        var gfiLayers = GfiControl.getLayers();
-                                                        // par defaut, le controle GFI ne devrait pas ajouter pas les couches
-                                                        // vecteurs dans sa liste de couches requetables...
-                                                        // si on renseigne queryable:true, on doit ajouter cette couche de la liste...
-                                                        // mais, on verifie qu'elle n'exsite pas déjà !
-                                                        if (p.options.queryable === true) {
-                                                            var bfound = false;
-                                                            for (var i = 0; i < gfiLayers.length; i++) {
-                                                                if (gfiLayers[i].obj === p.layer) {
-                                                                    bfound = true;
+                                                            // si on renseigne queryable:false, on doit retirer cette couche de la liste...
+                                                            if (p.options.queryable === false) {
+                                                                var _layers = [];
+                                                                for (var ii = 0; ii < gfiLayers.length; ii++) {
+                                                                    if (gfiLayers[ii].obj !== p.layer) {
+                                                                        _layers.push(gfiLayers[ii]);
+                                                                    }
                                                                 }
-                                                            }
-                                                            if (!bfound) {
-                                                                gfiLayers.push({
-                                                                    obj : p.layer,
-                                                                    event : "singleclick",
-                                                                    infoFormat : "" // peu importe !?
-                                                                });
+                                                                GfiControl.setLayers(_layers);
                                                             }
                                                         }
-                                                        // si on renseigne queryable:false, on doit retirer cette couche de la liste...
-                                                        if (p.options.queryable === false) {
-                                                            var _layers = [];
-                                                            for (var ii = 0; ii < gfiLayers.length; ii++) {
-                                                                if (gfiLayers[ii].obj !== p.layer) {
-                                                                    _layers.push(gfiLayers[ii]);
-                                                                }
-                                                            }
-                                                            GfiControl.setLayers(_layers);
-                                                        }
-                                                    }
-                                                })
-                                                .then(function () {
-                                                    // other stuff..
-                                                })
-                                                .catch(function (e) {
-                                                    // TODO styles utilisateurs par defaut !
-                                                    // throw new Error("Apply Style error = " + e.message);
-                                                    // self.logger.warn("DEBUG:Apply Style error = " + e.message);
-                                                });
-                                        };
+                                                    })
+                                                    .then(function () {
+                                                        // other stuff..
+                                                    })
+                                                    .catch(function (e) {
+                                                        // TODO styles utilisateurs par defaut !
+                                                        // throw new Error("Apply Style error = " + e.message);
+                                                        // self.logger.warn("DEBUG:Apply Style error = " + e.message);
+                                                    });
+                                            };
 
-                                        // enregistrement du layer
-                                        var _id = (_multiSources) ? layerId + "-" + p.id : layerId;
-                                        self._layers.push({
-                                            id : _id,
-                                            obj : p.layer,
-                                            options : p.options
-                                        });
+                                            // enregistrement du layer
+                                            var _id = (_multiSources) ? layerId + "-" + p.id : layerId;
+                                            self._layers.push({
+                                                id : _id,
+                                                obj : p.layer,
+                                                options : p.options
+                                            });
 
-                                        // ajout du layer sur la carte
-                                        map.addLayer(p.layer);
+                                            // ajout du layer sur la carte
+                                            map.addLayer(p.layer);
 
-                                        // FIXME
-                                        // le tilejson est async donc les informations ne sont pas encore disponibles
-                                        // pour les properties mapbox-*
-                                        // ce fichier met à jour les filtres attributaires du style princial !!!
+                                            // FIXME
+                                            // le tilejson est async donc les informations ne sont pas encore disponibles
+                                            // pour les properties mapbox-*
+                                            // et ce fichier met à jour les filtres attributaires du style principal !!!
 
-                                        // ajout du style complet dans la carte pour une utilisation
-                                        // eventuelle (ex. editeur)
-                                        // > map.set("mapbox-styles")
-                                        var _allStyles = map.get(OlMap.MAPBOXPROPERTIES["styles"]) || {};
-                                        _allStyles[_id] = p.styles;
-                                        map.set(OlMap.MAPBOXPROPERTIES["styles"], _allStyles);
-                                        map.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableMapStyles.bind(self));
-                                        // debug
-                                        map.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["styles"]);
+                                            // ajout du style complet dans la carte pour une utilisation
+                                            // eventuelle (ex. editeur)
+                                            // > map.set("mapbox-styles")
+                                            var _allStyles = map.get(OlMap.MAPBOXPROPERTIES["styles"]) || {};
+                                            _allStyles[_id] = p.styles;
+                                            map.set(OlMap.MAPBOXPROPERTIES["styles"], _allStyles);
+                                            map.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableMapStyles.bind(self));
+                                            map.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["styles"]);
 
-                                        // ajout du style de la couche uniquement
-                                        // (multisource === plusieurs couches !)
-                                        // pour une utilisation eventuelle (ex. editeur)
-                                        // > layer.set("mapbox-styles")
-                                        var _stylesClone = JSON.parse(JSON.stringify(p.styles)); // clone
-                                        var _glLayers = _stylesClone.layers;
-                                        for (var ii = 0; ii < _glLayers.length; ii++) {
-                                            var _glLayer = _glLayers[ii];
-                                            // on ecarte les sources differentes : 1 source = 1 layer
-                                            if (_glLayer.source !== p.id) {
-                                                _glLayers.splice(ii, 1);
-                                                ii--;
-                                                continue;
+                                            // ajout du style de la couche uniquement
+                                            // (multisource === plusieurs couches !)
+                                            // pour une utilisation eventuelle (ex. editeur)
+                                            // > layer.set("mapbox-styles")
+                                            var _cloneStyle = JSON.parse(JSON.stringify(p.styles)); // clone
+                                            var _glLayers = _cloneStyle.layers;
+                                            for (var ii = 0; ii < _glLayers.length; ii++) {
+                                                var _glLayer = _glLayers[ii];
+                                                // on ecarte les sources differentes : 1 source = 1 layer
+                                                if (_glLayer.source !== p.id) {
+                                                    _glLayers.splice(ii, 1);
+                                                    ii--;
+                                                    continue;
+                                                }
+                                                // et, on ecarte les filtres attributaires
+                                                if (_glLayer.metadata &&
+                                                    _glLayer.metadata.hasOwnProperty("geoportail:category") &&
+                                                    _glLayer.metadata.hasOwnProperty("geoportail:filter")) {
+                                                    _glLayers.splice(ii, 1);
+                                                    ii--;
+                                                    continue;
+                                                }
                                             }
-                                            // et, on ecarte les filtres attributaires
-                                            if (_glLayer.metadata &&
-                                                _glLayer.metadata.hasOwnProperty("geoportail:category") &&
-                                                _glLayer.metadata.hasOwnProperty("geoportail:filter")) {
-                                                _glLayers.splice(ii, 1);
-                                                ii--;
-                                                continue;
+                                            p.layer.set(OlMap.MAPBOXPROPERTIES["styles"], _cloneStyle);
+
+                                            // ajout des differents themes de la couche
+                                            // pour une utilisation eventuelle (ex. portail ou editeur)
+                                            // > layer.set("mapbox-themes")
+                                            p.layer.set(OlMap.MAPBOXPROPERTIES["themes"], {
+                                                stylesSummary : p.options.stylesSummary,
+                                                styles : p.options.styles
+                                            });
+
+                                            // ajout des differents filtres attributaires de la couche
+                                            // pour une utilisation eventuelle (ex. portail ou editeur)
+                                            // > layer.set("mapbox-filters")
+                                            p.layer.set(OlMap.MAPBOXPROPERTIES["filters"], {
+                                                filtersSummary : p.options.filtersSummary,
+                                                filters : p.options.filters
+                                            });
+
+                                            // ajout des statuts
+                                            // - themes,
+                                            // - filtres,
+                                            // - layers.
+                                            // pour une utilisation eventuelle (ex. portail ou editeur)
+                                            // ces statuts sont aussi transmis au permalien...
+                                            // > layer.set("mapbox-status")
+                                            p.layer.set(OlMap.MAPBOXPROPERTIES["status"], {
+                                                "theme" : p.selectedTheme,
+                                                "layers" : p.selectedLayers, // TODO !
+                                                "filters" : p.selectedFilters
+                                            });
+
+                                            // gestion du style N/B
+                                            if (p.options.grayScaled) {
+                                                // transformation du json en N/B
+                                                // le style "gray" n'est pas enregistré dans
+                                                // les properties !
+                                                // c'est un style temporaire...
+                                                p.styles = _transformGrayStyle(_cloneStyle);
+                                                if (!p.styles) {
+                                                    // eslint-disable-next-line no-console
+                                                    console.error("Erreur de transformation en N/B !?");
+                                                }
                                             }
-                                        }
-                                        p.layer.set(OlMap.MAPBOXPROPERTIES["styles"], _stylesClone);
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["styles"], self._callbackMapBoxObservableStyles.bind(self));
-                                        // debug
-                                        p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["styles"]);
 
-                                        // ajout des differents themes de la couche
-                                        // pour une utilisation eventuelle (ex. portail ou editeur)
-                                        // > layer.set("mapbox-themes")
-                                        p.layer.set(OlMap.MAPBOXPROPERTIES["themes"], {
-                                            stylesSummary : p.options.stylesSummary,
-                                            styles : p.options.styles
-                                        });
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["themes"], self._callbackMapBoxObservableThemes.bind(self));
-                                        // debug
-                                        p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["themes"]);
-
-                                        // ajout des differents filtres attributaires de la couche
-                                        // pour une utilisation eventuelle (ex. portail ou editeur)
-                                        // > layer.set("mapbox-filters")
-                                        p.layer.set(OlMap.MAPBOXPROPERTIES["filters"], {
-                                            filtersSummary : p.options.filtersSummary,
-                                            filters : p.options.filters
-                                        });
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["filters"], self._callbackMapBoxObservableFilters.bind(self));
-                                        // debug
-                                        p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["filters"]);
-
-                                        // ajout des statuts
-                                        // - themes,
-                                        // - filtres,
-                                        // - layers.
-                                        // pour une utilisation eventuelle (ex. portail ou editeur)
-                                        // ces statuts sont aussi transmis au permalien...
-                                        // > layer.set("mapbox-status")
-                                        p.layer.set(OlMap.MAPBOXPROPERTIES["status"], {
-                                            "theme" : p.selectedTheme,
-                                            "layers" : p.selectedLayers, // TODO !
-                                            "filters" : p.selectedFilters
-                                        });
-                                        p.layer.on("change:" + OlMap.MAPBOXPROPERTIES["status"], self._callbackMapBoxObservableStatus.bind(self));
-                                        // debug
-                                        p.layer.dispatchEvent("change:" + OlMap.MAPBOXPROPERTIES["status"]);
-
-                                        // gestion du style N/B
-                                        if (p.options.grayScaled) {
-                                            // transformation du json en N/B
-                                            // le style "gray" n'est pas enregistré dans
-                                            // les properties !
-                                            // c'est un style temporaire...
-                                            p.styles = _transformGrayStyle(_stylesClone);
-                                            if (!p.styles) {
-                                                // eslint-disable-next-line no-console
-                                                console.error("Erreur de transformation en N/B !?");
+                                            // application du style
+                                            if (p.layer.getSource()) {
+                                                setStyle();
+                                            } else {
+                                                p.layer.once("change:source", setStyle);
                                             }
-                                        }
 
-                                        // application du style
-                                        if (p.layer.getSource()) {
-                                            setStyle();
-                                        } else {
-                                            p.layer.once("change:source", setStyle);
-                                        }
-
-                                        // Maintenant que la couche mapBox a été ajoutée de manière asynchrone,
-                                        // on s'assure de bien remettre à jour les indexs des couches et de
-                                        // reordonner les couches correctement (désynchro des zIndex dans le cas d'un switch 3D->2D)
-                                        // On entre pas dans la condition si les IDs des couches ne correspondent pas entre
-                                        // les couches contenues dans_layers et mapOptions.layersOptions
-                                        // cf. FIXME couche ORTHO dans afterGetConfig
-                                        for (var i = 0; i < self._layers.length; i++) {
-                                            var layerName = self._layers[i].id;
-                                            if (self.mapOptions.layersOptions && self.mapOptions.layersOptions[layerName] && self.mapOptions.layersOptions[layerName].position !== undefined) {
-                                                self._layers[i].options.position = self.mapOptions.layersOptions[layerName].position;
-                                                self._layers[i].obj.setZIndex(self._layers[i].options.position);
+                                            // Maintenant que la couche mapBox a été ajoutée de manière asynchrone,
+                                            // on s'assure de bien remettre à jour les indexs des couches et de
+                                            // reordonner les couches correctement (désynchro des zIndex dans le cas d'un switch 3D->2D)
+                                            // On entre pas dans la condition si les IDs des couches ne correspondent pas entre
+                                            // les couches contenues dans_layers et mapOptions.layersOptions
+                                            // cf. FIXME couche ORTHO dans afterGetConfig
+                                            for (var i = 0; i < self._layers.length; i++) {
+                                                var layerName = self._layers[i].id;
+                                                if (self.mapOptions.layersOptions && self.mapOptions.layersOptions[layerName] && self.mapOptions.layersOptions[layerName].position !== undefined) {
+                                                    self._layers[i].options.position = self.mapOptions.layersOptions[layerName].position;
+                                                    self._layers[i].obj.setZIndex(self._layers[i].options.position);
+                                                }
                                             }
-                                        }
 
-                                        // maj du gestionnaire de couche
-                                        self._addLayerConfToLayerSwitcher(p.layer, p.options);
+                                            // maj du gestionnaire de couche
+                                            self._addLayerConfToLayerSwitcher(p.layer, p.options);
 
-                                        // FIXME pb async !
-                                        // On est dans un thread async (à cause du fetch),
-                                        // et l'abonnement (cf. IMap.prototype.addLayers)
-                                        // est executé avant que la couche soit ajouté
-                                        // à l'objet this._layers...
-                                        // On realise donc un reabonnement à la volée
-                                        // dans ce thread afin d'être sûr d'avoir nos
-                                        // abonnements corrects !
-                                        self._resetLayerChangedEvent();
-                                    })(params);
+                                            // FIXME pb async !
+                                            // On est dans un thread async (à cause du fetch),
+                                            // et l'abonnement (cf. IMap.prototype.addLayers)
+                                            // est executé avant que la couche soit ajouté
+                                            // à l'objet this._layers...
+                                            // On realise donc un reabonnement à la volée
+                                            // dans ce thread afin d'être sûr d'avoir nos
+                                            // abonnements corrects !
+                                            self._resetLayerChangedEvent();
+                                        })(params);
+                                    };
+
+                                    if (vectorTileJson) {
+                                        self.logger.warn("tilejson loading!");
+                                        vectorLayer.once("change:" + OlMap.MAPBOXPROPERTIES["loaded"], launch);
+                                    } else {
+                                        self.logger.warn("loaded!");
+                                        launch();
+                                    }
                                 }
                             }
                         })
@@ -2105,13 +2136,14 @@ OlMap.prototype._updateFilterMapBoxLayer = function (layer, id, options) {
         }
     }
 
+    // TODO
+    // si on change la visibilité, il faut donc mettre à jour les styles
+    // attributaires
+
     // Retour d'une promise mais sans données...
     return applyStyleOlms(layer, style, source)
         .then(function () {
-            // TODO
             // maj des styles attributaires du layer : mapbox-filters
-            // si on change la visibilité, il faut donc mettre à jour les styles
-            // attributaires
             var _filters = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["filters"])));
             if (_filters) {
                 if (_filters.filters) {
@@ -2134,22 +2166,36 @@ OlMap.prototype._updateFilterMapBoxLayer = function (layer, id, options) {
             }
         })
         .then(function () {
-            // TODO
             // maj des styles du layer : mapbox-styles
-            // si on change la visibilité, il faut donc mettre à jour les styles
-            // du layer : les styles impactés par le filtre
+            var _cloneStyle = JSON.parse(JSON.stringify(style)); // clone
+            var _glLayers = _cloneStyle.layers;
+            for (var ii = 0; ii < _glLayers.length; ii++) {
+                var _glLayer = _glLayers[ii];
+                // on ecarte les sources differentes : 1 source = 1 layer
+                if (_glLayer.source !== source) {
+                    _glLayers.splice(ii, 1);
+                    ii--;
+                    continue;
+                }
+                // et, on ecarte les filtres attributaires
+                if (_glLayer.metadata &&
+                    _glLayer.metadata.hasOwnProperty("geoportail:category") &&
+                    _glLayer.metadata.hasOwnProperty("geoportail:filter")) {
+                    _glLayers.splice(ii, 1);
+                    ii--;
+                    continue;
+                }
+            }
+            layer.set(OlMap.MAPBOXPROPERTIES["styles"], _cloneStyle);
         })
         .then(function () {
-            // TODO
             // maj des styles de la carte : mapbox-styles
-            // si on change la visibilité, il faut donc mettre à jour les styles
-            // de la map : les styles attributaires ainsi que les styles impactés
-            // par le filtre
+            var _allStyles = JSON.parse(JSON.stringify(map.get(OlMap.MAPBOXPROPERTIES["styles"]) || {}));
+            _allStyles[id] = style;
+            map.set(OlMap.MAPBOXPROPERTIES["styles"], _allStyles);
         })
         .then(function () {
             // maj du statut : mapbox-status
-            // si on change la visibilité, il faut donc mettre à jour le statut
-            // des filtres
             var _status = JSON.parse(JSON.stringify(layer.get(OlMap.MAPBOXPROPERTIES["status"])));
             if (_status) {
                 // [{k:categorie1, v: [0,1,0,1]},{k:categorie2, v:[0,0,0,0]}]


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [x] Les tests (`npm run test`) sont passés localement

## Type de Pull request

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [x] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [x] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation

## Quel est le comportement actuel (avant PR) :

Il n’existe pas d'exemple d'implémentation des menu sur les thèmes et filtres sur le vecteur tuilé.
De plus, il est utile d'avoir des événements sur les changement de propriétés (ex. mapbox-styles) de la couche.

## Quel est le nouveau comportement :

- ajout  des événements 'change' sur les properties 'mapbox-*'
- exemple d’implémentation du menu des thèmes et des filtres

![capture](https://user-images.githubusercontent.com/10401006/85000732-1ae77600-b153-11ea-85b4-fd64fae00469.png)

![ezgif-3-aec24f4f9c64](https://user-images.githubusercontent.com/10401006/85001127-90ebdd00-b153-11ea-8a7b-5b366c939150.gif)

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non


## Autres informations

 - correctifs eslint
 - corrige le BUG sur le ticket RDEV 34601