### PR TITLE
fix(3D:VectorTiles): sync layer/label visibility

### DIFF
--- a/src/Interface/IMapBase.js
+++ b/src/Interface/IMapBase.js
@@ -62,7 +62,7 @@ var switch2D3D = function (viewMode) {
                 y : lonlat[1]
             };
         }
-        
+
         if (mode === "2d") {
             // transformation des coordonnées de géographiques en planes
             // FIXME : ne devrait pas se faire avec ol.proj mais avec proj4 car dans IMap, ol n'est pas forcement chargée !
@@ -143,7 +143,7 @@ var switch2D3D = function (viewMode) {
                 }
             }
         }
-        
+
         if (mode === "2d") {
             // 3d -> 2d
             _overview.layers = [];

--- a/src/Itowns/ItMapBase.js
+++ b/src/Itowns/ItMapBase.js
@@ -2,7 +2,7 @@ import { IMap } from "../Interface/IMap";
 import Logger from "../Utils/LoggerByDefault";
 // itowns & extended extensions
 import { itownsExtended } from "geoportal-extensions-itowns";
-import { Coordinates, THREE } from "itowns";
+import { Coordinates } from "itowns";
 
 /**
 * Itowns IMap implementation class.

--- a/src/Itowns/ItMapLayers.js
+++ b/src/Itowns/ItMapLayers.js
@@ -959,10 +959,10 @@ ItMap.prototype._addMapBoxLayer = function (layerObj) {
 
     // overloads the showLabels option to false if the layer is not visible
     if (layerOpts.visibility === false) {
-      layerOpts.showLabels = false;
+        layerOpts.showLabels = false;
     } else {
-      // vector tile layers labels handling
-      layerOpts.showLabels = layerOpts.showLabels === undefined ? true : layerOpts.showLabels;
+        // vector tile layers labels handling
+        layerOpts.showLabels = layerOpts.showLabels === undefined ? true : layerOpts.showLabels;
     }
 
     var vectorTileSource = new VectorTilesSource(vectorTileSourceOpts);

--- a/src/Itowns/ItMapLayers.js
+++ b/src/Itowns/ItMapLayers.js
@@ -956,6 +956,15 @@ ItMap.prototype._addMapBoxLayer = function (layerObj) {
     if (layerOpts.sprite) {
         vectorTileSourceOpts.sprite = layerOpts.sprite;
     }
+
+    // overloads the showLabels option to false if the layer is not visible
+    if (layerOpts.visibility === false) {
+      layerOpts.showLabels = false;
+    } else {
+      // vector tile layers labels handling
+      layerOpts.showLabels = layerOpts.showLabels === undefined ? true : layerOpts.showLabels;
+    }
+
     var vectorTileSource = new VectorTilesSource(vectorTileSourceOpts);
 
     var vectorTileLayer = {};
@@ -966,7 +975,7 @@ ItMap.prototype._addMapBoxLayer = function (layerObj) {
             return false;
         },
         noTextureParentOutsideLimit : true,
-        labelEnabled : layerOpts.showLabels || true,
+        labelEnabled : layerOpts.showLabels,
         source : vectorTileSource
     });
 


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [x] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [x] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :

Lors d'un switch 2D->3D avec couche vecteur tuilée invisible, les labels apparaissent comme visibles en 3D. 
<!-- Décrire le comportement actuel qui est modifié, pourquoi il est modifié et, eventuellement, citer des tickets concernés -->

Numéro du ticket : RDEV-36067


## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Lors d'un switch 2D->3D avec couche vecteur tuilée invisible, les labels n'apparaissent plus (synchro visibilité<->labels en 3D)

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

<!-- Autres informations importantes concernant cette PR comme la liste des tickets concernés, ou des screenshots qui illustrent les changements introduits par cette PR. -->
