### PR TITLE
fix(center): corrige le centrage par geocodage en multiclés

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -1,12 +1,10 @@
-# SDK Geoportail 2D/3D, version 3.3.6
+# SDK Geoportail 2D/3D, version 3.3.7
 
-**28/01/2022 : version 3.3.6**
+**xx/02/2022 : version 3.3.7**
 
 > Release SDK Geoportail 2D/3D
 
 ## Summary
-
-Mise à jour de la documentation et des extensions geoportail pour openlayers en version 3.2.7
 
 ## Changelog
 
@@ -14,12 +12,11 @@ Mise à jour de la documentation et des extensions geoportail pour openlayers en
 
 * [Changed]
 
-    - Mise à jour de la documentation et des README (#88)
-    - Mise à jour des extensions geoportail pour openlayers en version 3.2.7
-
 * [Removed]
 
 * [Fixed]
+
+    - correction de la fonction de centrage par geocodage avec multiclés et autoconf local (#89)
 
 * [Deprecated]
 

--- a/samples-src/pages/2d/page-center-amd.html
+++ b/samples-src/pages/2d/page-center-amd.html
@@ -45,6 +45,10 @@
             Gp.Map.load('geoportalMap1',{
                 // apiKey : "{{apikey}}",
                 configUrl : "{{resources}}/autoconf.js",
+                zoom : 17,
+                center : {
+                    location : "36 avenue d'Italie, paris"
+                },
                 mapEventsOptions : {
                 "mapLoaded" : function () {
                     loadMap2()

--- a/samples-src/pages/2d/page-center-bundle.html
+++ b/samples-src/pages/2d/page-center-bundle.html
@@ -39,6 +39,10 @@
         Gp.Map.load('geoportalMap1',{
             // apiKey : "{{apikey}}",
             configUrl : "{{resources}}/autoconf.js",
+            center : {
+                location : "36 avenue d'Italie, Paris"
+            },
+            zoom : 17,
             mapEventsOptions : {
                 "mapLoaded" : function () {
                     loadMap2()

--- a/src/Interface/IMapView.js
+++ b/src/Interface/IMapView.js
@@ -104,16 +104,16 @@ IMap.prototype.centerGeolocate = function () {
             function (position) {
                 self.logger.trace("[IMap] found center by geolocation (" + position.coords.longitude + ", " + position.coords.latitude + ")");
                 var point = {
-                    x: position.coords.longitude,
-                    y: position.coords.latitude,
-                    projection: "EPSG:4326"
+                    x : position.coords.longitude,
+                    y : position.coords.latitude,
+                    projection : "EPSG:4326"
                 };
                 // paramater zoomLevel (=17 by default) used for 3D setAutoCenter function only
                 self.setAutoCenter(point, 17);
                 // declenchement de l'evenement "geolocated"
                 var e = IMap.CustomEvent("geolocated", {
-                    detail: {
-                        position: point
+                    detail : {
+                        position : point
                     }
                 });
                 self.div.dispatchEvent(e);

--- a/src/Interface/IMapView.js
+++ b/src/Interface/IMapView.js
@@ -26,7 +26,7 @@ IMap.prototype.centerGeocode = function (opts) {
 
     // si plusieurs clés en entrée, on récupère toutes les ressources par clé
     var keys = this.apiKey.split(",");
-    for (var i=0; i<keys.length; i++) {
+    for (var i = 0; i < keys.length; i++) {
         layersIds[keys[i]] = Config.getLayersId(keys[i]);
     }
     var locTypes = opts.locationType || ["StreetAddress", "PositionOfInterest"];
@@ -34,18 +34,18 @@ IMap.prototype.centerGeocode = function (opts) {
     fo.type = [];
     fo.keys = [];
     // pour chaque clé en entrée, on va vérifier à quelle ressource de géocodage elle a accès
-    for (var i=0; i<keys.length; i++) {
+    for (var k = 0; k < keys.length; k++) {
         var checkLocTypes = locTypes;
         while (checkLocTypes.length > 0) {
             var lt = checkLocTypes.pop();
-            if (layersIds[keys[i]].indexOf(lt + "$OGC:OPENLS;Geocode") >= 0) {
+            if (layersIds[keys[k]].indexOf(lt + "$OGC:OPENLS;Geocode") >= 0) {
                 this.logger.trace("[IMap] centerGeocode : found rights for " + lt);
                 fo.type.push(lt);
                 // on récupère toutes les clés ayant accès à au moins une ressource de géocodage
-                fo.keys.push(keys[i]);
+                fo.keys.push(keys[k]);
             }
         }
-    }   
+    }
     // Si on n'a rien trouve, on ne peut pas geocoder
     if (fo.type.length === 0) {
         this.logger.info("no rights for geocoding services");

--- a/src/Interface/IMapView.js
+++ b/src/Interface/IMapView.js
@@ -63,28 +63,28 @@ IMap.prototype.centerGeocode = function (opts) {
     var map = this;
     // On appelle le service de geocodage avec la première clé ayant accès à une ressource de géocodage
     Services.geocode({
-        apiKey: fo.keys[0],
-        location: opts.location,
-        filterOptions: fo,
+        apiKey : fo.keys[0],
+        location : opts.location,
+        filterOptions : fo,
         // si le service de geocodage répond
-        onSuccess: function (geocodeResponse) {
+        onSuccess : function (geocodeResponse) {
             map.logger.trace("[IMap] found center by geocoding (" + geocodeResponse.locations[0].position.x + ", " + geocodeResponse.locations[0].position.y + ")");
             var point = {
-                x: geocodeResponse.locations[0].position.y,
-                y: geocodeResponse.locations[0].position.x,
-                projection: "EPSG:4326"
+                x : geocodeResponse.locations[0].position.y,
+                y : geocodeResponse.locations[0].position.x,
+                projection : "EPSG:4326"
             };
             map.setAutoCenter(point);
             // declenchement de l'evenement "located"
             var e = IMap.CustomEvent("located", {
-                detail: {
-                    position: point
+                detail : {
+                    position : point
                 }
             });
             map.div.dispatchEvent(e);
         },
         // si le service de géocodage échoue
-        onFailure: function () {
+        onFailure : function () {
             this.logger.info("Erreur du service de géocodage !!!");
         }
     });


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [x] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
<!-- Décrire le comportement actuel qui est modifié, pourquoi il est modifié et, eventuellement, citer des tickets concernés -->

Voir https://www.developpez.net/forums/d2125851/applications/sig-systeme-d-information-geographique/ign-api-geoportail/erreur-l-appel-geocodage-passage-cle-publique/

Le code suivant, censé centrer la carte sur l'adresse donnée au chargement, ne fonctionne pas.

```
        Gp.Map.load('geoportalMap1',{
            apiKey : "cartes,essentiels",
            zoom : 17,
            center : {
                location : "36 avenue d'Italie, paris"
            }
        });
```


## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->

Le code suivant, censé centrer la carte sur l'adresse donnée au chargement,  fonctionne.
```
        Gp.Map.load('geoportalMap1',{
            apiKey : "cartes,essentiels",
            zoom : 17,
            center : {
                location : "36 avenue d'Italie, paris"
            }
        });
```
## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

Si plusieurs clés ont accès à au moins une ressource de géocodage, seule la première de la liste sera utilisée pour appeler le service de géocodage sur la fonction centerGeocode du SDK.
<!-- Autres informations importantes concernant cette PR comme la liste des tickets concernés, ou des screenshots qui illustrent les changements introduits par cette PR. -->
