### PR TITLE
bug sur l'affichage du vecteur tuilé en superposition à d'autre couche

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # SDK Geoportail 2D/3D, version 3.3.7
 
-**xx/02/2022 : version 3.3.7**
+**03/02/2022 : version 3.3.7**
 
 > Release SDK Geoportail 2D/3D
 
@@ -16,7 +16,7 @@
 
 * [Fixed]
 
-    - correction de la fonction de centrage par geocodage avec multiclés et autoconf local (#89)
+    - bug sur l'affichage du vecteur tuilé en superposition avec une autre couche (cf. <https://github.com/openlayers/openlayers/issues/9970>)
 
 * [Deprecated]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * [Fixed]
 
+    - correction de la fonction de centrage par geocodage avec multiclés et autoconf local (#89)
     - bug sur l'affichage du vecteur tuilé en superposition avec une autre couche (cf. <https://github.com/openlayers/openlayers/issues/9970>)
 
 * [Deprecated]

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "geoportal-sdk",
-    "version": "3.3.6",
-    "date": "28/01/2022",
-    "SDK2DVersion": "3.3.6",
-    "SDK3DVersion": "3.3.6",
+    "version": "3.3.7",
+    "date": "03/02/2022",
+    "SDK2DVersion": "3.3.7",
+    "SDK3DVersion": "3.3.7",
     "description": "French Geoportal SDK based on OpenLayers (2D) and iTowns (3D) libraries",
     "main": "dist/2d/GpSDK2D-src.js, dist/3d/GpSDK3d-src.js",
     "module": "src/SDK2D.js, src/SDK3D.js",

--- a/samples-src/pages/2d/page-mapbox-planign-geoportail-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-planign-geoportail-bundle.html
@@ -39,8 +39,8 @@
                 "layerimport" : {}
             },
             layersOptions : {
-                'GEOGRAPHICALGRIDSYSTEMS.MAPS': {
-                },
+                "ORTHOIMAGERY.ORTHOPHOTOS" : {},
+                'GEOGRAPHICALGRIDSYSTEMS.MAPS': {},
                 'PLAN.IGN.GEOPORTAIL' : {
                     format : "MapBox",
                     url : "{{resources}}/MAPBOX/styles/PLAN.IGN.GEOPORTAIL.json"

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -1233,6 +1233,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             vectorSource._legends = _legends;
                                             vectorSource._originators = _originators;
                                             vectorLayer = new VectorTileLayer({
+                                                className : _title,
                                                 source : vectorSource,
                                                 visible : false,
                                                 zIndex : _position, // FIXME gerer l'ordre sur des multisources ?
@@ -1247,6 +1248,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                 // featureClass : RenderFeature
                                             });
                                             vectorLayer = new VectorTileLayer({
+                                                className : _title,
                                                 visible : false,
                                                 zIndex : _position,
                                                 declutter : true // utile ? option ?
@@ -1483,6 +1485,7 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                         vectorSource._legends = _legends;
                                         vectorSource._originators = _originators;
                                         vectorLayer = new VectorTileLayer({
+                                            className : _title,
                                             source : vectorSource,
                                             visible : false,
                                             zIndex : _position, // FIXME gerer l'ordre sur des multisources ?


### PR DESCRIPTION
Le passage à OpenLayers 6.9.0 a généré quelques problèmes d'affichage du vecteur tuilé en superposition à d'autre couche : 
![Capture-20220203204339-804x782](https://user-images.githubusercontent.com/10401006/152419779-1f932fa4-3f0a-403d-9afd-96c33afd669a.png)
![Capture-20220203204318-808x786](https://user-images.githubusercontent.com/10401006/152420353-1b545d1a-1a07-41a5-8246-80fd381aaee3.png)

**La solution d'Andreas Hocevar :** 
cf. issue https://github.com/openlayers/openlayers/issues/9970
![image](https://user-images.githubusercontent.com/10401006/152420596-41efaeed-ca03-4d2d-808e-7a8b86eef743.png)

**Pour tester le correctif :** 
`samples-src/pages/2d/page-mapbox-planign-bundle.html`

Ce correctif doit corriger les remarques contenues dans le document suivant : 
[Recette géoportail janvier 2022.pdf](https://github.com/IGNF/geoportal-sdk/files/7997842/Recette.geoportail.janvier.2022.pdf)

