### PR TITLE
Ajouter une contrainte d’échelle avec le zoom "mousewheel"

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * [Added]
 
+  - Appliquer une contrainte d’échelle avec le zoom "mousewheel" et la touche SHIFT  
+
 * [Changed]
 
 * [Removed]

--- a/README-SDK-3D.md
+++ b/README-SDK-3D.md
@@ -2,32 +2,32 @@
 
 <!-- toc -->
 
-- [Mise en oeuvre](#mise-en-oeuvre)
-  * [Téléchargement](#telechargement)
-    + [Téléchargement direct](#telechargement-direct)
-    + [Récupération avec NPM](#recuperation-avec-npm)
-    + [Accès direct](#acces-direct)
-  * [Intégration dans une page web](#integration-dans-une-page-web)
-  * [Utilisation dans module ES6](#utilisation-dans-module-es6)
-  * [Interfaces de programmation](#interfaces-de-programmation)
-  * [Création et affichage d'une carte](#creation-et-affichage-dune-carte)
-  * [Configuration de l'accès à la plateforme Géoportail](#configuration-de-lacces-a-la-plateforme-geoportail)
-  * [Configuration dynamique](#configuration-dynamique)
-  * [Optimisation du chargement : configuration locale](#optimisation-du-chargement--configuration-locale)
-  * [Configuration du centrage de la carte](#configuration-du-centrage-de-la-carte)
-    + [Centrage par coordonnées](#centrage-par-coordonnees)
-    + [Centrage en utilisant le service de géocodage du Géoportail](#centrage-en-utilisant-le-service-de-geocodage-du-geoportail)
-    + [Centrage par géolocalisation du terminal utilisé](#centrage-par-geolocalisation-du-terminal-utilise)
-  * [Configuration des couches utilisées pour composer la carte](#configuration-des-couches-utilisees-pour-composer-la-carte)
-    + [Affichage des couches Géoportail WMS et WMTS](#affichage-des-couches-geoportail-wms-et-wmts)
-    + [Affichage des couches "externes"](#affichage-des-couches-externes)
-  * [Configuration des markers - visu 2D uniquement](#configuration-des-markers---visu-2d-uniquement)
-  * [Configuration des outils additionnels à proposer sur la carte](#configuration-des-outils-additionnels-a-proposer-sur-la-carte)
-  * [Abonnement aux intéractions des utilisateurs avec la carte](#abonnement-aux-interactions-des-utilisateurs-avec-la-carte)
-  * [Bascule entre 2D et 3D](#bascule-entre-2d-et-3d)
-  * [Autres possibilités de paramétrage](#autres-possibilites-de-parametrage)
-  * [Gestion des projections](#gestion-des-projections)
-  * [Interaction avec la carte créée](#interaction-avec-la-carte-creee)
+- [Kit de Développement (SDK) Géoportail - version 3D](#kit-de-développement-sdk-géoportail---version-3d)
+  - [Mise en oeuvre](#mise-en-oeuvre)
+    - [Téléchargement](#téléchargement)
+      - [Téléchargement direct](#téléchargement-direct)
+      - [Récupération avec NPM](#récupération-avec-npm)
+      - [Accès direct](#accès-direct)
+    - [Intégration dans une page web](#intégration-dans-une-page-web)
+    - [Utilisation dans module ES6](#utilisation-dans-module-es6)
+    - [Interfaces de programmation](#interfaces-de-programmation)
+    - [Création et affichage d'une carte](#création-et-affichage-dune-carte)
+    - [Configuration de l'accès à la plateforme Géoportail](#configuration-de-laccès-à-la-plateforme-géoportail)
+    - [Configuration dynamique](#configuration-dynamique)
+    - [Optimisation du chargement : configuration locale](#optimisation-du-chargement--configuration-locale)
+    - [Configuration du centrage de la carte](#configuration-du-centrage-de-la-carte)
+      - [Centrage par coordonnées](#centrage-par-coordonnées)
+      - [Centrage en utilisant le service de géocodage du Géoportail](#centrage-en-utilisant-le-service-de-géocodage-du-géoportail)
+      - [Centrage par géolocalisation du terminal utilisé](#centrage-par-géolocalisation-du-terminal-utilisé)
+    - [Configuration des couches utilisées pour composer la carte](#configuration-des-couches-utilisées-pour-composer-la-carte)
+      - [Affichage des couches Géoportail WMS et WMTS](#affichage-des-couches-géoportail-wms-et-wmts)
+      - [Affichage des couches "externes"](#affichage-des-couches-externes)
+    - [Configuration des markers - visu 2D uniquement](#configuration-des-markers---visu-2d-uniquement)
+    - [Configuration des outils additionnels à proposer sur la carte](#configuration-des-outils-additionnels-à-proposer-sur-la-carte)
+    - [Abonnement aux intéractions des utilisateurs avec la carte](#abonnement-aux-intéractions-des-utilisateurs-avec-la-carte)
+    - [Bascule entre 2D et 3D](#bascule-entre-2d-et-3d)
+    - [Autres possibilités de paramétrage](#autres-possibilités-de-paramétrage)
+    - [Interaction avec la carte créée](#interaction-avec-la-carte-créée)
 
 <!-- tocstop -->
 
@@ -522,6 +522,8 @@ Les outils disponibles en 2D et 3D sont les suivants :
 Les outils disponibles en 2D uniquement sont les suivants :
 
 * boutons de zoom (["zoom"](https://ignf.github.io/geoportal-sdk/latest/jsdoc/Gp.ControlOptions.html#zoom)) ;
+
+  > **astuce** : il est possible de forcer le zoom sur les contraintes d'échelles avec la _molette_ de zoom de la souris et la touche SHIFT enfoncée
 
 * barre de recherche (["search"](https://ignf.github.io/geoportal-sdk/latest/jsdoc/Gp.ControlOptions.html#searchctrl))
 

--- a/src/OpenLayers/OlMapBase.js
+++ b/src/OpenLayers/OlMapBase.js
@@ -3,6 +3,15 @@ import { IMap } from "../Interface/IMap";
 import View from "ol/View";
 import Map from "ol/Map";
 
+import {
+    MouseWheelZoom,
+    defaults as defaultInteractions
+} from "ol/interaction";
+
+import {
+    shiftKeyOnly as eventShiftKeyOnly
+} from "ol/events/condition";
+
 /**
  * OpenLayers IMap implementation class.
  *
@@ -69,7 +78,10 @@ OlMap.prototype._initMap = function () {
 
     // creation de la map vide
     this.libMap = new Map({
-        // interactions : interactions,
+        interactions : defaultInteractions().extend([new MouseWheelZoom({
+            constrainResolution : true,
+            condition : eventShiftKeyOnly
+        })]),
         target : this.div,
         view : view
         // controls : controls


### PR DESCRIPTION
Par défaut, toutes les interactions de la carte sont celles définies par _Openlayers_.

Pour le zoom molette (_mousewheel_), il n'y aucune contrainte sur le zoom, donc possibilité de faire des **zooms intermédiaires**. 

Il est possible de surcharger le comportement en fixant les contraintes au zoom : 
```js
this.libMap = new Map({
        interactions : defaultInteractions().extend([new MouseWheelZoom({
            constrainResolution : true,
            condition : eventShiftKeyOnly
        })]),
        target : this.div,
        view : view
        // controls : controls
    });
```
Le comportement implémenté est le suivant : 
* zoom intermédiaires par défaut
* mais si la touche **SHIFT** du clavier est pressé, les contraintes sont appliquées sur le zoom.

Les contraintes de résolution ou d'échelles appliquées au zoom _mousewheel_ permet d'avoir une meilleur gestion du cache sur des données _requêtées_ en WMS. 

Le comportement forcé uniquement sur les contraintes peut être appliqué par défaut : 
```js
this.libMap = new Map({
        interactions : defaultInteractions().extend([new MouseWheelZoom({
            constrainResolution : true
        })]),
        target : this.div,
        view : view
        // controls : controls
    });
```
Mais, on perd la possibilité d'avoir des zooms intermédiaires !

> Personnellement, je ne suis pas fan de contraindre le zoom aux échelles. 
> C'est intéressante pour le WMS (mais très peu utilisé sur le portail! !?), mais sans impact pour le vecteur tuilé ou le WMTS.
> Le zoom intermédiaire pour le vecteur tuilé apporte une fluidité dans la navigation.