### PR TITLE
Ajout des événements sur le rendu des styles pour les couches MapBox

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -18,6 +18,8 @@
 
 * [Fixed]
 
+  - Ajout des evenements (map) : "render:success" / "render:failure" pour l'application du rendu des styles sur des couches MapBox
+
 * [Deprecated]
 
 * [Security]

--- a/samples-src/pages/2d/page-mapbox-accesstoken-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-accesstoken-bundle.html
@@ -21,7 +21,7 @@
 
 {{#content "js"}}
     <script>
-        Gp.Map.load('geoportalMap',{
+        var map = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
             center:{
                 x : 407444,
@@ -47,6 +47,12 @@
                 }
             },
             zoom : 6
+        });
+        map.getLibMap().on("render:failure", function (e) {
+            console.error(e);
+        });
+        map.getLibMap().on("render:success", function (e) {
+            console.info(e);
         });
     </script>
 {{/content}}

--- a/samples-src/pages/2d/page-mapbox-enseignements-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-enseignements-bundle.html
@@ -21,7 +21,7 @@
 
 {{#content "js"}}
     <script>
-        Gp.Map.load('geoportalMap',{
+        var map = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
             center:{
                 x : 407444,
@@ -72,6 +72,13 @@
                 }
             },
             zoom : 6
+        });
+
+        map.getLibMap().on("render:failure", function (e) {
+            console.error(e);
+        });
+        map.getLibMap().on("render:success", function (e) {
+            console.info(e);
         });
     </script>
 {{/content}}

--- a/samples-src/pages/2d/page-mapbox-geojson-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-geojson-bundle.html
@@ -21,7 +21,7 @@
 
 {{#content "js"}}
     <script>
-        Gp.Map.load('geoportalMap',{
+        var map = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
             center:{
                 x : 407444,
@@ -72,6 +72,13 @@
                 }
             },
             zoom : 6
+        });
+
+        map.getLibMap().on("render:failure", function (e) {
+            console.error(e);
+        });
+        map.getLibMap().on("render:success", function (e) {
+            console.info(e);
         });
     </script>
 {{/content}}

--- a/samples-src/pages/2d/page-mapbox-geojson-failed-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-geojson-failed-bundle.html
@@ -21,7 +21,7 @@
 
 {{#content "js"}}
     <script>
-        Gp.Map.load('geoportalMap',{
+        var map = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
             center:{
                 x : 407444,
@@ -53,6 +53,9 @@
                 }
             },
             zoom : 6
+        });
+        map.getLibMap().on("render:failure", function (e) {
+            console.error(e);
         });
     </script>
 {{/content}}

--- a/samples-src/pages/2d/page-mapbox-layerimport-planign-bundle.html
+++ b/samples-src/pages/2d/page-mapbox-layerimport-planign-bundle.html
@@ -21,7 +21,7 @@
 
 {{#content "js"}}
     <script>
-        Gp.Map.load('geoportalMap',{
+        var map = Gp.Map.load('geoportalMap',{
             configUrl : "{{resources}}/autoconf.js",
             center:{
                 x : 407444,
@@ -53,6 +53,13 @@
                 'GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2': {}
             },
             zoom : 4
+        });
+
+        map.getLibMap().on("render:failure", function (e) {
+            console.error(e);
+        });
+        map.getLibMap().on("render:success", function (e) {
+            console.info(e);
         });
     </script>
 {{/content}}

--- a/src/Map.js
+++ b/src/Map.js
@@ -362,6 +362,30 @@ var autoPanOptions = {
  * | grayScaled | Boolean |  If true, the layer is displayed in gray-scale. |
  * | zoomToExtent | Boolean | If true, zoom into the extent of features. |
  *
+ * Event :
+ *
+ * | Name | Attached on | Description |
+ * | - | - | - |
+ * | render:success | map | Event triggered when the rendering of the style on the map layer was successful |
+ * | render:failure  | map | Event fired when style rendering on map layer fails |
+ *
+ * Example :
+ * ```js
+ * // listener
+ * map.getLibMap().on("render:failure", function (evt) {
+ *   console.error(evt);
+ *   // object :
+ *   // detail : { id, error, target }
+ * });
+ *
+ * map.getLibMap().on("render:success", function (evt) {
+ *   console.info(evt);
+ *   // object :
+ *   // detail : { id, style, target }
+ *  });
+ * ```
+ *
+ *
  * **Specific 3D properties**
  *
  * | property | Type | Description |
@@ -623,7 +647,7 @@ var layerOptions = {
  * | - | - | - |
  * | div | String / DOMElement | Target HTML element container or its id. Default is chosen by map implementation.
  * | maximised | Boolean | if the control has to be opened or not. |
- * 
+ *
  * **Specific 3D options**
  *
  * | property | Type | Description |
@@ -839,8 +863,7 @@ var layerOptions = {
  * | defaultVisibility | Boolean | Display the building when the globe is initialized - true by default |
  * | minZoom | Number | Minimum zoom level to display the buildings - 15 by default |
  *
- * 
- * 
+ *
  * <a id="searchctrl"></a>
  *
  * ### Options for "search" control

--- a/src/OpenLayers/OlMapVectorTile.js
+++ b/src/OpenLayers/OlMapVectorTile.js
@@ -2,6 +2,7 @@
 // la complexité du code de la fonction principale : _addVectorLayer().
 
 import { OlMap } from "./OlMapBase";
+import { IMap } from "../Interface/IMap";
 
 import { olUtils as Utils } from "geoportal-extensions-openlayers";
 
@@ -1642,12 +1643,30 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                                         }
                                                     })
                                                     .then(function () {
-                                                        // other stuff..
+                                                        var event = IMap.CustomEvent("render:success", {
+                                                            detail : {
+                                                                id : p.id,
+                                                                style : p.styles
+                                                            }
+                                                        });
+                                                        Object.defineProperty(event, "target", {
+                                                            writable : true
+                                                        });
+                                                        map.dispatchEvent(event);
                                                     })
                                                     .catch(function (e) {
                                                         // TODO styles utilisateurs par defaut !
-                                                        // throw new Error("Apply Style error = " + e.message);
                                                         self.logger.warn("DEBUG:Apply Style error = " + e.message);
+                                                        var event = IMap.CustomEvent("render:failure", {
+                                                            detail : {
+                                                                id : p.id,
+                                                                error : e
+                                                            }
+                                                        });
+                                                        Object.defineProperty(event, "target", {
+                                                            writable : true
+                                                        });
+                                                        map.dispatchEvent(event);
                                                     });
                                             };
 
@@ -1662,7 +1681,6 @@ OlMap.prototype._addMapBoxLayer = function (layerObj) {
                                             }
 
                                             // enregistrement du layer
-                                            var _id = (_multiSources) ? layerId + "-" + p.id : layerId;
                                             self._layers.push({
                                                 id : _id,
                                                 obj : p.layer,


### PR DESCRIPTION
Ajout des événements pour l'application du rendu des styles sur les couches MapBox :

- "render:success"
- "render:failure"

Exemple de _listeners_ :
```js
map.on("render:failure", function (e) {
  // le rendu du style sur la couche est en échec
  console.error(e);
})

map.on("render:success", function (e) {
   // le rendu du style sur la couche est bien appliqué
  console.info(e);
})
```

ref. https://github.com/IGNF/geoportal-extensions/pull/342