### PR TITLE
Import / Export des couches de calcul

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -6,9 +6,41 @@
 
 ## Summary
 
+- Option d'export et import des couches de calcul
+
 ## Changelog
 
 * [Added]
+
+    - Option d'export des tracés et des calculs au format GPX, KML et GeoJSON sur les contôles d'itineraire, d'isochrone et de profil altimétrique :
+
+        ```js
+            Gp.Map.load('map', {
+                configUrl : ,
+                azimuth : ,
+                zoom : ,
+                center : {},
+                layersOptions : {},
+                controlsOptions : {
+                    route : {
+                        export : true
+                    },
+                    isocurve : {
+                        export : {
+                            format : "gpx",
+                            name : "export-iso",
+                            title : "Exporter",
+                            menu : true
+                        }
+                    },
+                    elevationPath : {
+                        export : false
+                    }
+                }
+            });
+        ```
+
+    - Imports des couches de calculs (itineraire, isochrone et profil altimétrique) au format GPX, KML et GeoJSON.
 
 * [Changed]
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "expose-loader": "^0.7.5",
         "fs-extra": "^9.0.0",
         "geoportal-extensions-itowns": "2.3.10",
-        "geoportal-extensions-openlayers": "3.2.21",
+        "geoportal-extensions-openlayers": "https://raw.githubusercontent.com/IGNF/geoportal-extensions/feature/read-compute-extensions-format/build/scripts/release/geoportal-extensions-openlayers-3.2.21.tgz",
         "handlebars": "^4.7.5",
         "handlebars-layouts": "^3.1.4",
         "html-webpack-plugin": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "expose-loader": "^0.7.5",
         "fs-extra": "^9.0.0",
         "geoportal-extensions-itowns": "2.3.10",
-        "geoportal-extensions-openlayers": "https://raw.githubusercontent.com/IGNF/geoportal-extensions/feature/read-compute-extensions-format/build/scripts/release/geoportal-extensions-openlayers-3.2.21.tgz",
+        "geoportal-extensions-openlayers": "3.2.22",
         "handlebars": "^4.7.5",
         "handlebars-layouts": "^3.1.4",
         "html-webpack-plugin": "^4.0.4",

--- a/samples-src/pages/2d/page-controlsOptions-bundle.html
+++ b/samples-src/pages/2d/page-controlsOptions-bundle.html
@@ -109,6 +109,7 @@
                 route : {
                     // div : "extControlDiv",
                     // maximised : true,
+                    export : true,
                     exclusions : {
                         toll : true,
                         bridge : false,
@@ -125,6 +126,12 @@
                 isocurve : {
                     // div : "extControlDiv",
                     // maximised : true,
+                    export : {
+                        format : "gpx",
+                        name : "export-iso",
+                        title : "Exporter",
+                        menu : true
+                    },
                     exclusions : {
                         toll : true,
                         bridge : false,
@@ -237,6 +244,7 @@
                 },
                 elevationPath : {
                     // div : "extControlDiv",
+                    export : true,
                     styles : {
                         pointer : {
                             strokeColor : "rgba(19, 141, 117, 0.7)",

--- a/samples-src/pages/3d/page-switch-bundle.html
+++ b/samples-src/pages/3d/page-switch-bundle.html
@@ -93,6 +93,7 @@
                     },
                     route : {},
                     isocurve : {},
+                    elevationpath : {},
                     layerimport : {},
                     mousePosition : {
                         // div : "extControlDiv",

--- a/samples-src/resources/KML/croquis-sample.kml
+++ b/samples-src/resources/KML/croquis-sample.kml
@@ -1,5 +1,86 @@
-<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><Placemark><description>Une ligne
-</description><Style><LineStyle><color>ff3513e7</color><width>4</width></LineStyle></Style><LineString><coordinates>1.4062499999999998,48.94799948662481 2.5213623046875,48.51684692379888 1.8347167968749996,49.15680178017212</coordinates></LineString></Placemark><Placemark><description>Un marker 1
-</description><Style><IconStyle><Icon><href>http://api.ign.fr/api/images/api/markers/marker_01.png</href><gx:w>25</gx:w><gx:h>25</gx:h></Icon></IconStyle></Style><Point><coordinates>1.1151123046874996,48.65855637337026</coordinates></Point></Placemark><Placemark><description>Un marker 2
-</description><Style><IconStyle><Icon><href>http://api.ign.fr/api/images/api/markers/marker_02.png</href><gx:w>25</gx:w><gx:h>25</gx:h></Icon></IconStyle></Style><Point><coordinates>1.3732910156249996,48.4367329142394</coordinates></Point></Placemark><Placemark><description>Un marker 3</description><Style><IconStyle><Icon><href>http://api.ign.fr/api/images/api/markers/marker_03.png</href><gx:w>25</gx:w><gx:h>25</gx:h></Icon></IconStyle></Style><Point><coordinates>1.8951416015624998,48.38933334450539</coordinates></Point></Placemark><Placemark><description>Un polygone
-</description><Style><LineStyle><color>ffce3925</color><width>4</width></LineStyle><PolyStyle><color>3300f7ff</color></PolyStyle></Style><Polygon><outerBoundaryIs><LinearRing><coordinates>2.2412109374999996,48.319977556617204 2.9608154296875004,48.32363021503954 3.09814453125,48.70932952110317 2.647705078125,48.94439175521893 2.2412109374999996,48.319977556617204</coordinates></LinearRing></outerBoundaryIs></Polygon></Placemark><Placemark><name>Ici, un label !!!</name><Style><LabelStyle><color>ffff0000</color></LabelStyle></Style><Point><coordinates>1.4886474609375002,48.297812492437174</coordinates></Point></Placemark></Document></kml>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+    <Document>
+        <Placemark>
+            <description>Une ligne
+            </description>
+            <Style>
+                <LineStyle>
+                    <color>ff3513e7</color>
+                    <width>4</width>
+                </LineStyle>
+            </Style>
+            <LineString>
+                <coordinates>1.4062499999999998,48.94799948662481 2.5213623046875,48.51684692379888
+                    1.8347167968749996,49.15680178017212</coordinates>
+            </LineString>
+        </Placemark>
+        <Placemark>
+            <description>Un marker 1
+            </description>
+            <Style>
+                <IconStyle>
+                    <Icon>
+                        <href>http://api.ign.fr/api/images/api/markers/marker_01.png</href>
+                        <gx:w>25</gx:w>
+                        <gx:h>25</gx:h>
+                    </Icon>
+                </IconStyle>
+            </Style>
+            <Point>
+                <coordinates>1.1151123046874996,48.65855637337026</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark>
+            <description>Un marker 2
+            </description>
+            <Style>
+                <IconStyle>
+                    <Icon>
+                        <href>http://api.ign.fr/api/images/api/markers/marker_02.png</href>
+                        <gx:w>25</gx:w>
+                        <gx:h>25</gx:h>
+                    </Icon>
+                </IconStyle>
+            </Style>
+            <Point>
+                <coordinates>1.3732910156249996,48.4367329142394</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark>
+            <description>Un marker 3</description>
+            <Style>
+                <IconStyle><Icon><href>http://api.ign.fr/api/images/api/markers/marker_03.png</href><gx:w>25</gx:w><gx:h>25</gx:h></Icon></IconStyle>
+            </Style>
+            <Point>
+                <coordinates>1.8951416015624998,48.38933334450539</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark>
+            <description>Un polygone
+            </description>
+            <Style>
+                <LineStyle><color>ffce3925</color><width>4</width></LineStyle><PolyStyle><color>3300f7ff</color></PolyStyle>
+            </Style>
+            <Polygon>
+                <outerBoundaryIs>
+                    <LinearRing>
+                        <coordinates>2.2412109374999996,48.319977556617204 2.9608154296875004,48.32363021503954
+                            3.09814453125,48.70932952110317 2.647705078125,48.94439175521893
+                            2.2412109374999996,48.319977556617204</coordinates>
+                    </LinearRing>
+                </outerBoundaryIs>
+            </Polygon>
+        </Placemark>
+        <Placemark>
+            <name>Ici, un label !!!</name>
+            <Style>
+                <LabelStyle><color>ffff0000</color></LabelStyle>
+            </Style>
+            <Point>
+                <coordinates>1.4886474609375002,48.297812492437174</coordinates>
+            </Point>
+        </Placemark>
+    </Document>
+</kml>

--- a/src/Interface/IMapBase.js
+++ b/src/Interface/IMapBase.js
@@ -40,7 +40,7 @@ var switch2D3D = function (viewMode) {
             var layer = this._layers[index];
             // traitement des couches de calcul
             if (layer.options.format.toUpperCase() === "COMPUTE") {
-                // TODO :
+                // INFO :
                 // les styles pour la 2D et 3D sont ajoutés à la volée,
                 // une evolution est à mettre en place sur les contrôles, 
                 // les contrôles doivent transmettre les styles à la couche 2D & 3D.
@@ -61,52 +61,42 @@ var switch2D3D = function (viewMode) {
                 // la couche au format natif n'est pas utile pour la switch 2D<->3D.
                 var geojsonStr = null;
                 var geojsonObj = null;
-                switch (layer.options.control) {
-                    case "Itineraire":
-                        oldMap.layersOptions[layer.id].controlOptions = this.getLibMapControl("route").getData();
-                        geojsonStr = this.getLibMapControl("route").getGeoJSON();
-                        geojsonObj = JSON.parse(geojsonStr);
-                        geojsonObj.features.forEach(feature => {
-                            if (!feature.properties) {
-                                feature.properties = {};
-                            }
-                            if (feature.geometry.type === "Point") {
+                switch (layer.options.control.toUpperCase()) {
+                    case "ROUTE":
+                    case "ISOCURVE":
+                    case "ELEVATIONPATH":
+                            // on distingue le cas d'un import de calcul et un calcul en cours...
+                            oldMap.layersOptions[layer.id].controlOptions = (Object.keys(layer.options.controlOptions).length === 0)
+                                ? this.getLibMapControl(layer.options.control.toLowerCase()).getData() : layer.options.controlOptions;
+                            // on distingue le cas d'un import de calcul et un calcul en cours...
+                            geojsonStr = (Object.keys(layer.options.data).length === 0)
+                                ? this.getLibMapControl(layer.options.control.toLowerCase()).getGeoJSON() : layer.options.data;
+                            // on parse le geojson pour y ajouter des properties de styles (2D et 3D)
+                            geojsonObj = JSON.parse(geojsonStr);
+                            geojsonObj.features.forEach(feature => {
+                                if (!feature.properties) {
+                                    feature.properties = {};
+                                }
                                 // style propre à la 3D
-                                feature.properties.icon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAmCAYAAABpuqMCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQxSURBVFiF3ZldaBxVFMd/d2ayTRtjQpo2mlilWBEMshoj+FAERZIHIdA3iw+V1icRREFIQAKNgsUHQfBFwZI2WgWxqYUiVTDBBj9ILC5Nu2tjdjemsR+mSZNNNvsxO8eHTTRuk+zMnQmCf9iHnXvO+Z//nDvn3rmjRIT/C6zAI4ZVFRbtKDpQNCM0AvXANIo/EC4inMbmLBFZDJJaBVaZJ9Sd2HQCrwDbXHikgfewOMKPMh9ECsGIeVx1IHxEsQJeMY3iEMNy2m8aht8AtKpOhH70hADUI/TTqjr9puKvMsUE3vabxCp0MSJHdJ31xRSnVj9BVPcfOCj26U45PTHFh30c/am1EaaxuF+nKejd1WLX2gwhAPXL8T3De2XCqooKbuCu/eoiTZ6dXtch75WxaMeNENOyOXx8kHOpGMPOIudSMQ4fH8S0bBcs25Z5PMF7ZVpVL3BgQxvTsvn6+kVq6sK3jc3NRGhraKZgl9t9HGNEXvCSmvfKKJrL2nQfHVpTCEBNXZjuo0OB8JTAu5jiXmtjPL3vLl/jbnlKoNPN6spaVFbt8jXulqcEOmKSZS0yi5O+xt3ylEBHTLSsxbf913yNu+UpgU4DKE/Sc3AvczORNcfmZiL0HNwbCE8JvItxWDvJ1SjYFm0NzZzpG2RpIYbIIksLMc70Dbpsy+54SqCzzlQAY8B9Xsk8YAJ4gBHJe3HyXpkRyaN407OfN7zlVQjobjTv4BgQ1/ItjzjV9Oo46okZEBuhS8u3PDoZEDf7t9vg903zBLBfP8C/4cAnD87teclIGyFlLoVyllWh8vmQYRgVAOI4OQmFciKSFZFsMpmck1UC/Il5VNViEgHu9StkQYyb7bNNH1wrmDm3PgqWUHLBhl+SyeRV/6czLepJDAbw8fos4HTNb+/9PFv9u3YMU/X6f38/L98B7/gJ8U2uasiPEADTcRqDOozoBn7WcbzqmFOvpnYM+uTPpvP5SDBiimvP8xRPKV3DFpV7fX7HyYyD44M96xicmpqaSgd3TDQsv6J4zYvLx5nqsz/kK29qcyq5kFpafD+RSMSKf4P+CvCY+hJFRzmzmB2KPTvb+JnX8CsdzDGM8/F4/PrqseC/AggvZlGXtyipXc8kLcbCy6mdrg/6lBIbR41DYXR8cjIqIoW17IIXc17+nHnEOnS3VfhiHQt5d7HmVMK2Nn6+DHLiOGMmRLdMVI+NymjZ9Sf4abaMqZbQp01G/rnS60P5rT8duNXw1TpuGaXksmMYlxKJxLiIt23NponhKVV5a874rdZwmlYuTTvmjWdmGj9Mifl3kkpJ2hGJGY4THb9yJS4i2p0t+Gm2ggHJxMNb94eNzIAJZgEKbyxsP5kS00ZJSkG0oFQ0mZyYkKDuqIhs6u/7hyt75luM2RMPVfft3rW7bU9T0z2bxbV50+w/wF8f81R5OpwBhwAAAABJRU5ErkJggg==";
-                            }
-                            // style pour la 2D et 3D
-                            if (feature.geometry.type === "LineString") {
-                                feature.properties["stroke"] = "#00B798";
-                                feature.properties["stroke-opacity"] = 0.9;
-                                feature.properties["stroke-width"] = 12;
-                            }
-                        });
-                        oldMap.layersOptions[layer.id].data = JSON.stringify(geojsonObj);
-                        break;
-                    case "Isocurve":
-                        oldMap.layersOptions[layer.id].controlOptions = this.getLibMapControl("isocurve").getData();
-                        geojsonStr = this.getLibMapControl("isocurve").getGeoJSON();
-                        geojsonObj = JSON.parse(geojsonStr);
-                        geojsonObj.features.forEach(feature => {
-                            if (!feature.properties) {
-                                feature.properties = {};
-                            }
-                            if (feature.geometry.type === "Point") {
-                                // style propre à la 3D
-                                feature.properties.icon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAmCAYAAABpuqMCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQxSURBVFiF3ZldaBxVFMd/d2ayTRtjQpo2mlilWBEMshoj+FAERZIHIdA3iw+V1icRREFIQAKNgsUHQfBFwZI2WgWxqYUiVTDBBj9ILC5Nu2tjdjemsR+mSZNNNvsxO8eHTTRuk+zMnQmCf9iHnXvO+Z//nDvn3rmjRIT/C6zAI4ZVFRbtKDpQNCM0AvXANIo/EC4inMbmLBFZDJJaBVaZJ9Sd2HQCrwDbXHikgfewOMKPMh9ECsGIeVx1IHxEsQJeMY3iEMNy2m8aht8AtKpOhH70hADUI/TTqjr9puKvMsUE3vabxCp0MSJHdJ31xRSnVj9BVPcfOCj26U45PTHFh30c/am1EaaxuF+nKejd1WLX2gwhAPXL8T3De2XCqooKbuCu/eoiTZ6dXtch75WxaMeNENOyOXx8kHOpGMPOIudSMQ4fH8S0bBcs25Z5PMF7ZVpVL3BgQxvTsvn6+kVq6sK3jc3NRGhraKZgl9t9HGNEXvCSmvfKKJrL2nQfHVpTCEBNXZjuo0OB8JTAu5jiXmtjPL3vLl/jbnlKoNPN6spaVFbt8jXulqcEOmKSZS0yi5O+xt3ylEBHTLSsxbf913yNu+UpgU4DKE/Sc3AvczORNcfmZiL0HNwbCE8JvItxWDvJ1SjYFm0NzZzpG2RpIYbIIksLMc70Dbpsy+54SqCzzlQAY8B9Xsk8YAJ4gBHJe3HyXpkRyaN407OfN7zlVQjobjTv4BgQ1/ItjzjV9Oo46okZEBuhS8u3PDoZEDf7t9vg903zBLBfP8C/4cAnD87teclIGyFlLoVyllWh8vmQYRgVAOI4OQmFciKSFZFsMpmck1UC/Il5VNViEgHu9StkQYyb7bNNH1wrmDm3PgqWUHLBhl+SyeRV/6czLepJDAbw8fos4HTNb+/9PFv9u3YMU/X6f38/L98B7/gJ8U2uasiPEADTcRqDOozoBn7WcbzqmFOvpnYM+uTPpvP5SDBiimvP8xRPKV3DFpV7fX7HyYyD44M96xicmpqaSgd3TDQsv6J4zYvLx5nqsz/kK29qcyq5kFpafD+RSMSKf4P+CvCY+hJFRzmzmB2KPTvb+JnX8CsdzDGM8/F4/PrqseC/AggvZlGXtyipXc8kLcbCy6mdrg/6lBIbR41DYXR8cjIqIoW17IIXc17+nHnEOnS3VfhiHQt5d7HmVMK2Nn6+DHLiOGMmRLdMVI+NymjZ9Sf4abaMqZbQp01G/rnS60P5rT8duNXw1TpuGaXksmMYlxKJxLiIt23NponhKVV5a874rdZwmlYuTTvmjWdmGj9Mifl3kkpJ2hGJGY4THb9yJS4i2p0t+Gm2ggHJxMNb94eNzIAJZgEKbyxsP5kS00ZJSkG0oFQ0mZyYkKDuqIhs6u/7hyt75luM2RMPVfft3rW7bU9T0z2bxbV50+w/wF8f81R5OpwBhwAAAABJRU5ErkJggg==";
-                            }
-                            // style pour la 2D et 3D
-                            if (feature.geometry.type === "Polygon") {
-                                feature.properties["fill"] = "#00B798";
-                                feature.properties["fill-opacity"] = 0.7;
-                            }
-                        });
-                        oldMap.layersOptions[layer.id].data = JSON.stringify(geojsonObj);
-                        break;
+                                if (feature.geometry.type === "Point") {
+                                    feature.properties.icon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAmCAYAAABpuqMCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQxSURBVFiF3ZldaBxVFMd/d2ayTRtjQpo2mlilWBEMshoj+FAERZIHIdA3iw+V1icRREFIQAKNgsUHQfBFwZI2WgWxqYUiVTDBBj9ILC5Nu2tjdjemsR+mSZNNNvsxO8eHTTRuk+zMnQmCf9iHnXvO+Z//nDvn3rmjRIT/C6zAI4ZVFRbtKDpQNCM0AvXANIo/EC4inMbmLBFZDJJaBVaZJ9Sd2HQCrwDbXHikgfewOMKPMh9ECsGIeVx1IHxEsQJeMY3iEMNy2m8aht8AtKpOhH70hADUI/TTqjr9puKvMsUE3vabxCp0MSJHdJ31xRSnVj9BVPcfOCj26U45PTHFh30c/am1EaaxuF+nKejd1WLX2gwhAPXL8T3De2XCqooKbuCu/eoiTZ6dXtch75WxaMeNENOyOXx8kHOpGMPOIudSMQ4fH8S0bBcs25Z5PMF7ZVpVL3BgQxvTsvn6+kVq6sK3jc3NRGhraKZgl9t9HGNEXvCSmvfKKJrL2nQfHVpTCEBNXZjuo0OB8JTAu5jiXmtjPL3vLl/jbnlKoNPN6spaVFbt8jXulqcEOmKSZS0yi5O+xt3ylEBHTLSsxbf913yNu+UpgU4DKE/Sc3AvczORNcfmZiL0HNwbCE8JvItxWDvJ1SjYFm0NzZzpG2RpIYbIIksLMc70Dbpsy+54SqCzzlQAY8B9Xsk8YAJ4gBHJe3HyXpkRyaN407OfN7zlVQjobjTv4BgQ1/ItjzjV9Oo46okZEBuhS8u3PDoZEDf7t9vg903zBLBfP8C/4cAnD87teclIGyFlLoVyllWh8vmQYRgVAOI4OQmFciKSFZFsMpmck1UC/Il5VNViEgHu9StkQYyb7bNNH1wrmDm3PgqWUHLBhl+SyeRV/6czLepJDAbw8fos4HTNb+/9PFv9u3YMU/X6f38/L98B7/gJ8U2uasiPEADTcRqDOozoBn7WcbzqmFOvpnYM+uTPpvP5SDBiimvP8xRPKV3DFpV7fX7HyYyD44M96xicmpqaSgd3TDQsv6J4zYvLx5nqsz/kK29qcyq5kFpafD+RSMSKf4P+CvCY+hJFRzmzmB2KPTvb+JnX8CsdzDGM8/F4/PrqseC/AggvZlGXtyipXc8kLcbCy6mdrg/6lBIbR41DYXR8cjIqIoW17IIXc17+nHnEOnS3VfhiHQt5d7HmVMK2Nn6+DHLiOGMmRLdMVI+NymjZ9Sf4abaMqZbQp01G/rnS60P5rT8duNXw1TpuGaXksmMYlxKJxLiIt23NponhKVV5a874rdZwmlYuTTvmjWdmGj9Mifl3kkpJ2hGJGY4THb9yJS4i2p0t+Gm2ggHJxMNb94eNzIAJZgEKbyxsP5kS00ZJSkG0oFQ0mZyYkKDuqIhs6u/7hyt75luM2RMPVfft3rW7bU9T0z2bxbV50+w/wF8f81R5OpwBhwAAAABJRU5ErkJggg==";
+                                }
+                                // style pour la 2D et 3D
+                                if (feature.geometry.type === "LineString") {
+                                    feature.properties["stroke"] = "#00B798";
+                                    feature.properties["stroke-opacity"] = 0.9;
+                                    feature.properties["stroke-width"] = 12;
+                                }
+                                // style pour la 2D et 3D
+                                if (feature.geometry.type === "Polygon") {
+                                    feature.properties["fill"] = "#00B798";
+                                    feature.properties["fill-opacity"] = 0.7;
+                                }
+                            });
+                            oldMap.layersOptions[layer.id].data = JSON.stringify(geojsonObj);
+                            break;
                     default:
                         // TODO other format...
-                        // * les mesures
-                        // * profil alti
                         break;
                 }
             }
@@ -316,23 +306,20 @@ var switch2D3D = function (viewMode) {
                 // traitement des couches de calcul
                 if (clayer.options.format.toUpperCase() === "COMPUTE") {
                     var control = null;
-                    switch (clayer.options.control) {
-                        case "Itineraire":
-                            control = this.getLibMapControl("route");
-                            break;
-                        case "Isocurve":
-                            control = this.getLibMapControl("isocurve");
+                    switch (clayer.options.control.toUpperCase()) {
+                        case "ROUTE":
+                        case "ISOCURVE":
+                        case "ELEVATIONPATH":
+                            control = this.getLibMapControl(clayer.options.control.toLowerCase());
                             break;
                         default:
                             // TODO other format...
-                            // * les mesures
-                            // * profil alti
                             break;
                     }
                     if (control) {
                         control.setData(clayer.options.controlOptions);
                         control.setLayer(clayer.obj);
-                        control.setGeoJSON(clayer.options.data); // inutile ?
+                        // control.setGeoJSON(clayer.options.data); // inutile ?
                         control.init();
                     }
                 }

--- a/src/Map.js
+++ b/src/Map.js
@@ -957,6 +957,7 @@ var layerOptions = {
  * | defaultStyles | Object | Styles to apply by default to drawn features. |
  * | defaultStyles.textFillColor | String | Text fill color for labels (RGB hex value). |
  * | defaultStyles.textStrokeColor | String | Text surrounding color for labels (RGB hex value). |
+ * | defaultStyles.textStrokeWidth | Number | Text surrounding width for labels (RGB hex value). |
  * | defaultStyles.strokeColor | String | Stroke color (RGB hex value). |
  * | defaultStyles.polyFillColor | String | Polygons fill color (RGB hex value). |
  * | defaultStyles.polyFillOpacity | Number | Polygon fill opacity (alpha value between 0:transparent and 1:opaque). |
@@ -1010,6 +1011,7 @@ var controlOptions = {
 * | markerYAnchor | Float | Position of marker anchor in Y from top of the image expressed in pixels (for points styling). Default is 38. |
 * | textColor | String | Text fill color for labels (RGB hex value). Default is "#FFFFFF". |
 * | textStrokeColor | String | Text surrounding color for labels (RGB hex value). Default is "#000000". |
+* | textStrokeWidth | Number | Text surrounding width for labels (RGB hex value). Default is 4. |
 *
 * **Specific 3D properties (for GeoJSON only)**
 *

--- a/src/Map.js
+++ b/src/Map.js
@@ -590,6 +590,7 @@ var layerOptions = {
  * | - | - | - |
  * | div | String / DOMElement | Target HTML element container or its id. Default is chosen by map implementation.
  * | maximised | Boolean | if the control has to be opened or not. |
+ * | export | Boolean / Object | Specify if button "Export" is displayed. For the use of the options of the "Export" control, see {@link https://ignf.github.io/geoportal-extensions/openlayers-latest/jsdoc/ol.control.Export.html} |
  * | exclusions | Object | exclusions to be proposed for control. Il null all exclusions will be proposed by default. |
  * | exclusions.toll | Boolean | proposing toll exclusion. If true, this exclusion will be checked by default. |
  * | exclusions.bridge | Boolean | proposing bridge exclusion. If true, this exclusion will be checked by default. |
@@ -610,6 +611,7 @@ var layerOptions = {
  * | property | Type | Description |
  * | - | - | - |
  * | div | String / DOMElement | Target HTML element container or its id. Default is chosen by map implementation.
+ * | export | Boolean / Object | Specify if button "Export" is displayed. For the use of the options of the "Export" control, see {@link https://ignf.github.io/geoportal-extensions/openlayers-latest/jsdoc/ol.control.Export.html} |
  * | maximised | Boolean | if the control has to be opened or not. |
  * | exclusions | Object | exclusions to be proposed for control. Il null all exclusions will be proposed by default. |
  * | exclusions.toll | Boolean | proposing toll exclusion. If true, this exclusion will be checked by default. |
@@ -812,6 +814,7 @@ var layerOptions = {
  * | property | Type | Description |
  * | - | - | - |
  * | div | String / DOMElement | Target HTML element container or its id. Default is chosen by map implementation.
+ * | export | Boolean / Object | Specify if button "Export" is displayed. For the use of the options of the "Export" control, see {@link https://ignf.github.io/geoportal-extensions/openlayers-latest/jsdoc/ol.control.Export.html} |
  * | styles | Object | Styles to use to display the polygon area |
  * | styles.pointer | Object | Pointer (circle) style while measuring |
  * | styles.pointer.strokeColor | String | Stroke color |

--- a/src/OpenLayers/OlMapControls.js
+++ b/src/OpenLayers/OlMapControls.js
@@ -22,7 +22,8 @@ import {
     Icon as IconStyle,
     Stroke as StrokeStyle,
     Style,
-    Circle as CircleStyle
+    Circle as CircleStyle,
+    Text as TextStyle
 } from "ol/style";
 
 import TileLayer from "ol/layer/Tile";
@@ -532,6 +533,9 @@ OlMap.prototype.addIsocurveControl = function (controlOpts) {
  * @param {Number} [controlOpts.defaultStyles.KML.strokeOpacity = 0.8] - Stroke opacity for KML lines styling (alpha value between 0:transparent and 1:opaque)
  * @param {String} [controlOpts.defaultStyles.KML.polyFillColor = "#00B798"] - KML polygons fill color (RGB hex value).
  * @param {Number} [controlOpts.defaultStyles.KML.polyFillOpacity = 0.5] - KML polygons fill opacity (alpha value between 0:transparent and 1:opaque).
+ * @param {String} [controlOpts.defaultStyles.KML.textColor = "#FFFFFF"] - Text color for KML labels styling (RGB hex value).
+ * @param {String} [controlOpts.defaultStyles.KML.textStrokeColor = "#000000"] - Text surrounding color for KML labels styling (RGB hex value).
+ * @param {Number} [controlOpts.defaultStyles.KML.textStrokeWidth = 4] - Text surrounding width in pixels for KML labels styling.
  * @param {Object} [controlOpts.defaultStyles.GPX] - Styles to apply by default to imported GPX layers
  * @param {String} [controlOpts.defaultStyles.GPX.markerSrc] - URL of a marker image (for GPX waypoints styling). Default is an orange marker.
  * @param {Float} [controlOpts.defaultStyles.GPX.markerXAnchor = 25.5] - position of marker anchor in X from left of the image expressed in proportion of 1 (for GPX waypoints styling).
@@ -539,6 +543,9 @@ OlMap.prototype.addIsocurveControl = function (controlOpts) {
  * @param {String} [controlOpts.defaultStyles.GPX.strokeColor = "#002A50"] - Stroke color for GPX routes or tracks styling (RGB hex value).
  * @param {Number} [controlOpts.defaultStyles.GPX.strokeWidth = 4] - Stroke width in pixels for GPX routes or tracks styling.
  * @param {Number} [controlOpts.defaultStyles.GPX.strokeOpacity = 0.8] - Stroke opacity for GPX routes or tracks styling (alpha value between 0:transparent and 1:opaque)
+ * @param {String} [controlOpts.defaultStyles.GPX.textColor = "#FFFFFF"] - Text color for GPX labels styling (RGB hex value).
+ * @param {String} [controlOpts.defaultStyles.GPX.textStrokeColor = "#000000"] - Text surrounding color for GPX labels styling (RGB hex value).
+ * @param {Number} [controlOpts.defaultStyles.GPX.textStrokeWidth = 4] - Text surrounding width in pixels for GPX labels styling.
  * @param {Object} [controlOpts.defaultStyles.GeoJSON] - Styles to apply by default to imported GeoJSON layers
  * @param {String} [controlOpts.defaultStyles.GeoJSON.markerSrc] - URL of a marker image (for GeoJSON points styling). Default is an orange marker.
  * @param {Float} [controlOpts.defaultStyles.GeoJSON.markerXAnchor = 25.5] - position of marker anchor in X from left of the image expressed in proportion of 1 (for GeoJSON points styling).
@@ -548,6 +555,9 @@ OlMap.prototype.addIsocurveControl = function (controlOpts) {
  * @param {Number} [controlOpts.defaultStyles.GeoJSON.strokeOpacity = 0.8] - Stroke opacity for GeoJSON lines styling (alpha value between 0:transparent and 1:opaque)
  * @param {String} [controlOpts.defaultStyles.GeoJSON.polyFillColor = "#00B798"] - GeoJSON polygons fill color (RGB hex value).
  * @param {Number} [controlOpts.defaultStyles.GeoJSON.polyFillOpacity = 0.5] - GeoJSON polygons fill opacity (alpha value between 0:transparent and 1:opaque).
+ * @param {String} [controlOpts.defaultStyles.GeoJSON.textColor = "#FFFFFF"] - Text color for GeoJSON labels styling (RGB hex value).
+ * @param {String} [controlOpts.defaultStyles.GeoJSON.textStrokeColor = "#000000"] - Text surrounding color for GeoJSON labels styling (RGB hex value).
+ * @param {Number} [controlOpts.defaultStyles.GeoJSON.textStrokeWidth = 4] - Text surrounding width in pixels for GeoJSON labels styling.
  *
  * @return {Ol.control.LayerImport} control
  */
@@ -578,6 +588,10 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
         var strokeColor;
         var fillOpacity;
         var fillColor;
+        var textColor;
+        var textStrokeWidth;
+        var textStrokeColor;
+
         if (controlOpts.defaultStyles.KML) {
             var userKMLDefaultStyles = controlOpts.defaultStyles.KML;
             var kmldefaultStyleOptions = {};
@@ -599,6 +613,19 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
             kmldefaultStyleOptions.fill = new FillStyle({
                 color : IMap.prototype._hexToRgba.call(this, fillColor, fillOpacity)
             });
+            textColor = userKMLDefaultStyles.textColor || "#FFFFFF";
+            textStrokeColor = userKMLDefaultStyles.textStrokeColor || "#000000";
+            kmldefaultStyleOptions.text = new TextStyle({
+                font : "16px Sans",
+                textAlign : "left",
+                fill : new Fill({
+                    color : IMap.prototype._hexToRgba.call(this, textColor, 1)
+                }),
+                stroke : new Stroke({
+                    color : IMap.prototype._hexToRgba.call(this, textStrokeColor, 1),
+                    width : userKMLDefaultStyles.textStrokeWidth || 4
+                })
+            });
             var kmldefaultStyle = new Style(kmldefaultStyleOptions);
             importOpts.vectorStyleOptions.KML = {
                 defaultStyle : kmldefaultStyle
@@ -619,6 +646,19 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
             gpxdefaultStyleOptions.stroke = new StrokeStyle({
                 color : IMap.prototype._hexToRgba.call(this, strokeColor, strokeOpacity),
                 width : userGPXDefaultStyles.strokeWidth || 4
+            });
+            textColor = userGPXDefaultStyles.textColor || "#FFFFFF";
+            textStrokeColor = userGPXDefaultStyles.textStrokeColor || "#000000";
+            gpxdefaultStyleOptions.text = new TextStyle({
+                font : "16px Sans",
+                textAlign : "left",
+                fill : new Fill({
+                    color : IMap.prototype._hexToRgba.call(this, textColor, 1)
+                }),
+                stroke : new Stroke({
+                    color : IMap.prototype._hexToRgba.call(this, textStrokeColor, 1),
+                    width : userGPXDefaultStyles.textStrokeWidth || 4
+                })
             });
             var gpxdefaultStyle = new Style(gpxdefaultStyleOptions);
             importOpts.vectorStyleOptions.GPX = {
@@ -645,6 +685,19 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
             fillColor = userGeoJSONDefaultStyles.polyFillColor || "#00B798";
             geoJSONdefaultStyleOptions.fill = new FillStyle({
                 color : IMap.prototype._hexToRgba.call(this, strokeColor, strokeOpacity)
+            });
+            textColor = userGeoJSONDefaultStyles.textColor || "#FFFFFF";
+            textStrokeColor = userGeoJSONDefaultStyles.textStrokeColor || "#000000";
+            geoJSONdefaultStyleOptions.text = new TextStyle({
+                font : "16px Sans",
+                textAlign : "left",
+                fill : new Fill({
+                    color : IMap.prototype._hexToRgba.call(this, textColor, 1)
+                }),
+                stroke : new Stroke({
+                    color : IMap.prototype._hexToRgba.call(this, textStrokeColor, 1),
+                    width : userGeoJSONDefaultStyles.textStrokeWidth || 4
+                })
             });
             var geoJSONdefaultStyle = new Style(geoJSONdefaultStyleOptions);
             importOpts.vectorStyleOptions.GeoJSON = {

--- a/src/OpenLayers/OlMapControls.js
+++ b/src/OpenLayers/OlMapControls.js
@@ -421,6 +421,9 @@ OlMap.prototype.addRouteControl = function (controlOpts) {
     if (!this._isConfLoaded) {
         rteOpts.apiKey = this.apiKey;
     }
+    if (controlOpts.export) {
+        rteOpts.export = controlOpts.export;
+    }
     if (controlOpts.graphs) {
         rteOpts.graphs = controlOpts.graphs;
     }
@@ -479,6 +482,9 @@ OlMap.prototype.addIsocurveControl = function (controlOpts) {
     isoOpts.collapsed = !controlOpts.maximised;
     if (!this._isConfLoaded) {
         isoOpts.apiKey = this.apiKey;
+    }
+    if (controlOpts.export) {
+        isoOpts.export = controlOpts.export;
     }
     if (controlOpts.graphs) {
         isoOpts.graphs = controlOpts.graphs;
@@ -989,6 +995,9 @@ OlMap.prototype.addElevationPathControl = function (controlOpts) {
     // displayProfileOptions
     if (controlOpts.displayProfileOptions) {
         elevOpts.displayProfileOptions = controlOpts.displayProfileOptions;
+    }
+    if (controlOpts.export) {
+        elevOpts.export = controlOpts.export;
     }
     var control = new Ol.control.ElevationPath(elevOpts);
     this.libMap.addControl(control);

--- a/src/OpenLayers/OlMapControls.js
+++ b/src/OpenLayers/OlMapControls.js
@@ -618,10 +618,10 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
             kmldefaultStyleOptions.text = new TextStyle({
                 font : "16px Sans",
                 textAlign : "left",
-                fill : new Fill({
+                fill : new FillStyle({
                     color : IMap.prototype._hexToRgba.call(this, textColor, 1)
                 }),
-                stroke : new Stroke({
+                stroke : new StrokeStyle({
                     color : IMap.prototype._hexToRgba.call(this, textStrokeColor, 1),
                     width : userKMLDefaultStyles.textStrokeWidth || 4
                 })
@@ -652,10 +652,10 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
             gpxdefaultStyleOptions.text = new TextStyle({
                 font : "16px Sans",
                 textAlign : "left",
-                fill : new Fill({
+                fill : new FillStyle({
                     color : IMap.prototype._hexToRgba.call(this, textColor, 1)
                 }),
-                stroke : new Stroke({
+                stroke : new StrokeStyle({
                     color : IMap.prototype._hexToRgba.call(this, textStrokeColor, 1),
                     width : userGPXDefaultStyles.textStrokeWidth || 4
                 })
@@ -691,10 +691,10 @@ OlMap.prototype.addLayerImportControl = function (controlOpts) {
             geoJSONdefaultStyleOptions.text = new TextStyle({
                 font : "16px Sans",
                 textAlign : "left",
-                fill : new Fill({
+                fill : new FillStyle({
                     color : IMap.prototype._hexToRgba.call(this, textColor, 1)
                 }),
-                stroke : new Stroke({
+                stroke : new StrokeStyle({
                     color : IMap.prototype._hexToRgba.call(this, textStrokeColor, 1),
                     width : userGeoJSONDefaultStyles.textStrokeWidth || 4
                 })

--- a/src/OpenLayers/OlMapLayers.js
+++ b/src/OpenLayers/OlMapLayers.js
@@ -854,7 +854,7 @@ OlMap.prototype._registerUnknownLayer = function (layerObj) {
         options : options
     });
     var layerOpts = {};
-    layerOpts[layerId] = {};
+    layerOpts[layerId] = options;
 
     return layerOpts;
 };

--- a/src/OpenLayers/OlMapLayers.js
+++ b/src/OpenLayers/OlMapLayers.js
@@ -744,6 +744,14 @@ OlMap.prototype._registerUnknownLayer = function (layerObj) {
     var options = {};
 
     switch (layerId.toLowerCase()) {
+        case "measure:profil":
+            options.format = "COMPUTE";
+            options.graph = null;
+            options.control = "elevationpath";
+            options.title = "Profil altimétrique";
+            options.controlOptions = {};
+            options.data = {};
+            break;
         case "drawing":
             options.format = "drawing";
             break;
@@ -782,51 +790,53 @@ OlMap.prototype._registerUnknownLayer = function (layerObj) {
             options.format = "MAPBOX";
             break;
         case "layerimport:compute":
-            // TODO
-            // Evolution : à mettre en place au niveau des extensions
+            // INFO
             // Le widget d'import recherche si le fichier KML, GeoJSON ou GPX
             // est un fichier de calcul avec la lecture de la balise 'geoportail:compute'.
-            // Si oui, on modifie la property 'gpResultLayerId' -> layerimport:COMPUTE
-            // Et, on ajoute les options du calcul dans les properties de la couche.
+            // Si oui, property 'gpResultLayerId' -> 'layerimport:COMPUTE'
+            // Et, les options utiles au calcul sont dans les properties de la couche.
             options.format = "COMPUTE";
             var prop = layerObj.getProperties();
-            options.graph = prop.graph || "";
-            options.control = prop.control || "";
-            options.title = prop.title || "";
-            options.controlOptions = prop.controlOptions || {};
-            options.data = prop.data || {};
+            options.graph = prop.graph;
+            options.name = prop.name;
+            options.control = prop.control;
+            options.title = prop.title;
+            options.controlOptions = prop.data || {};
+            options.data = prop.geojson || {};
+            break;
+        case "voiture$ogc:openls;isocurve":
+        case "voiture$geoportail:gpp:isocurve":
+        case "voiture$ogc:openls;itineraire":
+        case "voiture$geoportail:gpp:itineraire":
+        case "pieton$ogc:openls;isocurve":
+        case "pieton$geoportail:gpp:isocurve":
+        case "pieton$ogc:openls;itineraire":
+        case "pieton$geoportail:gpp:itineraire":
+            // INFO
+            // Couches de calculs en cours avec les widgets : 
+            // - isocurve
+            // - route
+            var key = layerId.toLowerCase();
+            // result layer name
+            options.format = "COMPUTE";
+            // graph name (voiture / pieton)
+            options.graph = key.split(/[$:;]/)[0];
+            // control name (isocurve / itineraire)
+            options.name = key.split(/[$:;]/).slice(-1)[0];
+            // control real name
+            options.control = options.name;
+            if (options.name === "itineraire") {
+                options.control = "route";
+            }
+            // title by default
+            options.title = options.name + " (" + options.graph + ")";
+            // options control
+            options.controlOptions = {};
+            // features to geojson
+            options.data = {};
             break;
         default:
-            // FIXME 
-            // cas où l'ID est de la forme : 
-            //  ex. isochrones : 
-            //      Voiture$OGC:OPENLS;Isocurve
-            //      Voiture$GEOPORTAIL:GPP:Isocurve
-            //      Pieton$OGC:OPENLS;Isocurve
-            //      Pieton$GEOPORTAIL:GPP:Isocurve
-            //  ex. itineraire : 
-            //      Voiture$OGC:OPENLS;Itineraire
-            //      Voiture$GEOPORTAIL:GPP:Itineraire
-            //      Pieton$OGC:OPENLS;Itineraire
-            //      Pieton$GEOPORTAIL:GPP:Itineraire
-            var key = layerId.toLowerCase();
-            if (key.includes("ogc:openls;isocurve") || 
-                key.includes("ogc:openls;itineraire") || 
-                key.includes("geoportail:gpp:isocurve") ||
-                key.includes("geoportail:gpp:itineraire")) {
-                // result layer name
-                options.format = "COMPUTE";
-                // graph name (voiture / pieton)
-                options.graph = layerId.split(/[$:;]/)[0];
-                // control name (isocurve / itineraire)
-                options.control = layerId.split(/[$:;]/).slice(-1)[0];
-                // title by default
-                options.title = options.control + " (" + options.graph + ")";
-                // options control
-                options.controlOptions = {};
-                // features to geojson
-                options.data = {};
-            }
+            options.format = ""; // ???
             break;
     }
 


### PR DESCRIPTION
Possibilité d'importer des couches de calcul au format GPX, KML ou GeoJSON issues des outils : 
* isocurve
* route
* elevationpath

Ces couches de calculs sont en mode COMPUTE.
Ceci permet donc à ces couches d'être disponible en 3D.

Lors de l'import ou d'un switch 3D->2D d'une couche en mode COMPUTE, le contrôle associé est initialisé avec les paramètres du calcul et son tracé.

L'option **export** sur les contrôles ci dessus permet d'exporter les calculs et le tracé au format souhaité : 
```js
            Gp.Map.load('map', {
                configUrl : ,
                azimuth : ,
                zoom : ,
                center : {},
                layersOptions : {},
                controlsOptions : {
                    route : {
                        export : true
                    },
                    isocurve : {
                        export : {
                            format : "gpx",
                            name : "export-iso",
                            title : "Exporter",
                            menu : true
                        }
                    },
                    elevationPath : {
                        export : false
                    }
                }
            });
```

**RECETTE**

Pour les tests d'import :

> * Importer des fichiers de calcul (GPX, KML et GeoJSON) pour chaque type de calcul, et valider que le contrôle s'initialise correctement
> * **switcher** vers la 3D, et vérifier que le tracé est bien transmis avec le bon style et un nom de couche dans le gestionnaire de couche correct
> * **switcher** vers la 2D, et vérifier que le contrôle s'initialise correctement avec le bon style pour le tracé
>
> utiliser l'exemple : _samples-src/pages/3d/page-switch-bundle.html_

Pour les tests d'export : 

> * ajouter l'option **export** avec ou sans paramètres pour tous les contrôle de calcul
> * exporter le calcul au format souhaité
> * re importer cet export, et vérifier comme pour les tests d'import
> 
> utiliser l'exemple : _samples-src/pages/2d/page-controlsOptions-bundle.html_

Pour les tests de création d'un calcul : 

> * création d'un calcul avec les différents widgets de calcul
> * **switcher** vers la 3D, et vérifier que le tracé est bien transmis avec le bon style et un nom de couche dans le gestionnaire de couche correct
> * **switcher** vers la 2D, et vérifier que le contrôle s'initialise correctement avec le bon style pour le tracé
> 
> utiliser l'exemple : _samples-src/pages/3d/page-switch-bundle.html_

**Recette d'import avec les fichiers de calcul suivants :**
(disponible sur la  PR#363 https://github.com/IGNF/geoportal-extensions/pull/363)

- samples-src/resources/data/geojson/export-iso.geojson
- samples-src/resources/data/geojson/export-profil.geojson
- samples-src/resources/data/geojson/export-route.geojson

- samples-src/resources/data/gpx/export-iso.gpx
- samples-src/resources/data/gpx/export-profil.gpx
- samples-src/resources/data/gpx/export-route.gpx

- samples-src/resources/data/kml/export-iso.kml
- samples-src/resources/data/kml/export-profil.kml
- samples-src/resources/data/kml/export-route.kml